### PR TITLE
wget for webboot

### DIFF
--- a/webboot/webboot.go
+++ b/webboot/webboot.go
@@ -9,7 +9,14 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"io"
 	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"strings"
 
 	"github.com/u-root/webboot/pkg/dhclient"
 	"github.com/u-root/webboot/pkg/mountkexec"
@@ -17,52 +24,131 @@ import (
 )
 
 var (
-	cmd       = flag.String("cmd", "", "Command Line")
-	mountDir  = flag.String("dir", "/tmp/mountDir", "The mount point of the ISO")
-	ifName    = flag.String("interface", "^e.*", "Name of the interface")
-	timeout   = flag.Int("timeout", 15, "Lease timeout in seconds")
-	retry     = flag.Int("retry", 5, "Max number of attempts for DHCP clients to send requests. -1 means infinity")
-	verbose   = flag.Bool("verbose", false, "Verbose output")
-	ipv4      = flag.Bool("ipv4", true, "use IPV4")
-	ipv6      = flag.Bool("ipv6", true, "use IPV6")
-	osSystems = map[string]*webboot.Distro{
-		"tinycore": &webboot.Distro{"/boot/vmlinuz64", "/boot/corepure64.gz", "console=tty1", "https:louis.com"},
-		"TestISO":  &webboot.Distro{"/kernel", "/initiso.cpi", "console=ttyS0 console=tty0", "https:louis.com"},
+	cmd      = flag.String("cmd", "", "Command Line")
+	mountDir = flag.String("dir", "/tmp/mountDir", "The mount point of the ISO")
+	ifName   = flag.String("interface", "^e.*", "Name of the interface")
+	timeout  = flag.Int("timeout", 15, "Lease timeout in seconds")
+	retry    = flag.Int("retry", 5, "Max number of attempts for DHCP clients to send requests. -1 means infinity")
+	verbose  = flag.Bool("verbose", false, "Verbose output")
+	ipv4     = flag.Bool("ipv4", true, "use IPV4")
+	ipv6     = flag.Bool("ipv6", true, "use IPV6")
+	bookmark = map[string]*webboot.Distro{
+		"tinycore": &webboot.Distro{"/boot/vmlinuz64", "/boot/corepure64.gz", "console=tty1", "http://tinycorelinux.net/10.x/x86_64/release/CorePure64-10.1.iso"},
 	}
 )
+
+// parseArg takes a name and produces a filename and a URL
+// The URL can be used to download data to the file 'filename'
+// The argument is either a full URL or a bookmark.
+func parseArg(arg string) (string, string, error) {
+	var URL, filename string
+	if u, ok := bookmark[arg]; ok {
+		return u.DownloadLink, arg, nil
+	}
+
+	var err error
+	filename, err = name(arg)
+	URL = arg
+	if err != nil {
+		return "", "", fmt.Errorf("%v is not a valid URL: %v", URL, err)
+	}
+
+	return URL, filename, nil
+}
+
+// linkOpen returns an io.ReadCloser that holds the content of the URL
+func linkOpen(URL string) (io.ReadCloser, error) {
+	resp, err := http.Get(URL)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP Get failed: %v", resp.StatusCode)
+	}
+	return resp.Body, nil
+}
+
+// write copies the content from an io.readCloser to a named file with filename.
+func write(read io.ReadCloser, filename string) error {
+	w, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+
+	defer w.Close()
+	defer read.Close()
+
+	if _, err := io.Copy(w, read); err != nil {
+		return fmt.Errorf("Error copying %v: %v", filename, err)
+	}
+	return nil
+}
+
+// name takes a URL and generates a filename from it
+// For example, if a valid URL = http://tinycorelinux.net/10.x/x86_64/release/CorePure64-10.1.iso, then filename = CorePure64-10.1.iso
+// if the URL is empty or if the URL's Path ends in /, name returns a default index.html as the filename
+func name(URL string) (string, error) {
+	p, err := url.Parse(URL)
+
+	if err != nil {
+		return "", err
+	}
+	filename := "index.html"
+
+	if p.Path != "" && !strings.HasSuffix(p.Path, "/") {
+		filename = path.Base(p.Path)
+	}
+	return filename, nil
+}
+
+func usage() {
+	log.Printf("Usage: %s [ARGS] URL or name of ISO\n", os.Args[0])
+	flag.PrintDefaults()
+	os.Exit(1)
+}
 
 func main() {
 
 	flag.Parse()
 
+	if flag.NArg() != 1 {
+		usage()
+	}
+
 	dhclient.Request(*ifName, *timeout, *retry, *verbose, *ipv4, *ipv6)
 
-	if len(flag.Args()) < 1 {
-		log.Fatal("error:pass in an operating system")
+	arg := flag.Arg(0)
+
+	URL, filename, err := parseArg(arg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	//Processes the URL to receive an io.ReadCloser, which holds the content of the downloaded file
+	log.Println("Retrieving the file...")
+	read, err := linkOpen(URL)
+	if err != nil {
+		log.Fatal(err)
 	}
 
-	osname := flag.Args()[0]
-
-	if _, ok := osSystems[osname]; !ok {
-		log.Printf("error operating system is not supported,The following systems are supported")
-		for os := range osSystems {
-			log.Printf("%v", os)
-		}
-		log.Fatalf("exit")
+	err = write(read, filename)
+	if err != nil {
+		log.Fatal(err)
 	}
-	//Mount the downloaded ISO
-	if err := mountkexec.MountISO(osname, *mountDir); err != nil {
-		log.Fatalf("error in mountISO:%v", err)
+
+	if err = mountkexec.MountISO(filename, *mountDir); err != nil {
+		log.Fatalf("Error in mountISO:%v", err)
+
 	}
 	//Process the commandline input of the distro
-	if cmdline, err := webboot.CommandLine(osSystems[osname].Cmdline, *cmd); err != nil {
-		log.Fatalf("error in webbootCommandline:%v", err)
+	if cmdline, err := webboot.CommandLine(bookmark[filename].Cmdline, *cmd); err != nil {
+		log.Fatalf("Error in webbootCommandline:%v", err)
 	} else {
-		osSystems[osname].Cmdline = cmdline
+		bookmark[filename].Cmdline = cmdline
 	}
 
 	//Kexec into the new distro
-	if err := mountkexec.KexecISO(osSystems[osname], *mountDir); err != nil {
-		log.Fatalf("error in kexecISO:%v", err)
+	if err := mountkexec.KexecISO(bookmark[filename], *mountDir); err != nil {
+		log.Fatalf("Error in kexecISO:%v", err)
 	}
 }

--- a/webboot/webboot_test.go
+++ b/webboot/webboot_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"crypto/md5"
+	"encoding/hex"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type test struct {
+	name         string
+	linkOrName   string
+	md5link      string
+	expectedLink string
+	expectedName string
+}
+
+func TestParseArg(t *testing.T) {
+	tests := []test{
+		{name: "Debian", linkOrName: "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-10.0.0-amd64-netinst.iso", expectedLink: "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-10.0.0-amd64-netinst.iso", expectedName: "debian-10.0.0-amd64-netinst.iso"},
+		{name: "TinyCore", linkOrName: "tinycore", expectedLink: "http://tinycorelinux.net/10.x/x86_64/release/CorePure64-10.1.iso", expectedName: "tinycore"},
+		{name: "Ubuntu", linkOrName: "http://releases.ubuntu.com/18.04.2/ubuntu-18.04.2-desktop-amd64.iso", expectedLink: "http://releases.ubuntu.com/18.04.2/ubuntu-18.04.2-desktop-amd64.iso", expectedName: "ubuntu-18.04.2-desktop-amd64.iso"},
+	}
+
+	for _, v := range tests {
+		t.Run(v.name, func(t *testing.T) {
+			link, filename, err := parseArg(v.linkOrName)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Compare(link, v.expectedLink) != 0 {
+				t.Errorf("Looking up URL for %v: got %v, want %v", v.linkOrName, link, v.expectedLink)
+			}
+			if strings.Compare(filename, v.expectedName) != 0 {
+				t.Errorf("Looking up the file name for %v: got %v, want %v", v.linkOrName, filename, v.expectedName)
+			}
+		})
+	}
+}
+
+func TestName(t *testing.T) {
+	tests := []test{
+		{name: "TinyCore", linkOrName: "http://tinycorelinux.net/10.x/x86_64/release/CorePure64-10.1.iso", expectedName: "CorePure64-10.1.iso"},
+		{name: "ArchLinux", linkOrName: "http://mirrors.edge.kernel.org/archlinux/iso/2019.08.01/archlinux-2019.08.01-x86_64.iso", expectedName: "archlinux-2019.08.01-x86_64.iso"},
+		{name: "Ubuntu", linkOrName: "http://releases.ubuntu.com/18.04.2/ubuntu-18.04.2-desktop-amd64.iso", expectedName: "ubuntu-18.04.2-desktop-amd64.iso"},
+		{name: "HtmlFile", linkOrName: "http://releases.ubuntu.com", expectedName: "index.html"},
+	}
+	for _, v := range tests {
+		t.Run(v.name, func(t *testing.T) {
+			filename, err := name(v.linkOrName)
+			if err != nil {
+				t.Fatalf("Looking up the file name for %v: got %v, want nil", v.linkOrName, err)
+			}
+			if strings.Compare(filename, v.expectedName) != 0 {
+				t.Errorf("Looking for name to generate for %v: got %v, want %v", v.linkOrName, filename, v.expectedName)
+			}
+		})
+	}
+
+}
+
+func TestWrite(t *testing.T) {
+	content := []byte("temporary file's content")
+	tmpDir, err := ioutil.TempDir("", "tmpDir")
+	if err != nil {
+		t.Fatalf("Failed to create a temporary directory")
+	}
+	tmpfile := filepath.Join(tmpDir, "tmpfile")
+	if err := ioutil.WriteFile(tmpfile, content, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	file, err := os.Open(tmpfile)
+	if err != nil {
+		t.Fatalf("Failed to open %v: got %v, want nil", tmpfile, err)
+	}
+
+	testfn := filepath.Join(tmpDir, "testfile")
+	err = write(file, testfn)
+
+	read, err := ioutil.ReadFile(testfn)
+	if !bytes.Equal(content, read) {
+		t.Fatalf("Failed to write %v: got %v, want %v", testfn, string(read), string(content))
+	}
+}
+
+func TestLinkOpen(t *testing.T) {
+	tests := []test{
+		{name: "TinyCore", linkOrName: "http://tinycorelinux.net/10.x/x86_64/release/CorePure64-10.1.iso", md5link: "http://tinycorelinux.net/10.x/x86_64/release/CorePure64-10.1.iso.md5.txt"},
+		{name: "ArchLinux", linkOrName: "http://mirrors.edge.kernel.org/archlinux/iso/2019.08.01/archlinux-2019.08.01-x86_64.iso", md5link: "http://mirrors.edge.kernel.org/archlinux/iso/2019.08.01/md5sums.txt"},
+		//		Ubuntu takes too long to download right now for testing purposes. Test fails due to the download and testing being too long.
+		//		{name: "Ubuntu", linkOrName: "http://old-releases.ubuntu.com/releases/18.04.2/ubuntu-18.04.2-desktop-amd64.iso", md5link: "http://old-releases.ubuntu.com/releases/18.04.2/MD5SUMS"},
+	}
+
+	for _, v := range tests {
+		t.Run(v.name, func(t *testing.T) {
+			r, err := linkOpen(v.linkOrName)
+			if err != nil {
+				t.Fatalf("linkOpen %v: got %v, want nil", v.linkOrName, err)
+			}
+
+			body, err := ioutil.ReadAll(r)
+			if err != nil {
+				t.Fatalf("Failed to read %v: got %v, want nil", v.linkOrName, err)
+			}
+			//computes the hash of the ISO & converts it into a string to compare with md5.txt hash
+			md := md5.Sum(body)
+			hash := hex.EncodeToString(md[:])
+
+			c, err := linkOpen(v.md5link)
+			if err != nil {
+				t.Fatalf("linkOpen md5 %v: got %v, want nil", v.md5link, err)
+			}
+
+			var bytes []byte
+			if bytes, err = ioutil.ReadAll(c); err != nil {
+				t.Fatalf("Failed to read md5 %v: got %v, want nil", v.md5link, err)
+			}
+			// md5sum files contain a list of hashes. Here, we check each one
+			var found bool
+			for _, line := range strings.Split(string(bytes), "\n") {
+				if f := strings.Fields(line); len(f) != 0 && f[0] == hash {
+					found = true
+				}
+			}
+
+			if found != true {
+				t.Fatalf("Checking md5sum of %v against hashes in %v: could not find a hash to match %v", v.linkOrName, v.md5link, hash)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Webboot now has two functionalities: user either provides a URL link to
an ISO or user provides a name of ISO such that now we download the ISO
using an internal link.

If user provides a link, wget get retrieves the
ISO from the internet and uses the link to generate a name of the
output ISO file for the writer function to utilize.

If the user only gives a name, an internal link to the ISO's name is
used to download the ISO and the name of the ISO file is the same name
the user asked for.

Wget test cases downloads an ISO and its md5.txt file to check if the
downloaded ISO is not corrupted. It generates a hash from the downloaded
ISO and compares it with the hash from md5.txt file to confirm.

Signed-off-by: Urvisha Patel <patelvisha2007@gmail.com>