### PR TITLE
Add iwconfig and iwlist to Webboot initrd

### DIFF
--- a/buildimage.go
+++ b/buildimage.go
@@ -31,7 +31,8 @@ func main() {
 		{"date"},
 		{"go", "get", "-u", "github.com/u-root/u-root"},
 		{"go", "get", "-d", "-v", "-u", "github.com/u-root/NiChrome/..."},
-		{"go", "run", "github.com/u-root/u-root/.", *uroot, *cmds, *wcmds, *ncmds},
+		{"sudo", "apt", "install", "wireless-tools"},
+		{"go", "run", "github.com/u-root/u-root/.", "-files", "/sbin/iwconfig:bin/iwconfig", "-files", "/sbin/iwlist:bin/iwlist", *uroot, *cmds, *wcmds, *ncmds},
 	}
 	for _, cmd := range commands {
 		debug("Run %v", cmd)

--- a/webboot/webboot.go
+++ b/webboot/webboot.go
@@ -26,7 +26,7 @@ import (
 var (
 	cmd      = flag.String("cmd", "", "Command Line")
 	mountDir = flag.String("dir", "/tmp/mountDir", "The mount point of the ISO")
-	ifName   = flag.String("interface", "^e.*", "Name of the interface")
+	ifName   = flag.String("interface", "^[we].*", "Name of the interface")
 	timeout  = flag.Int("timeout", 15, "Lease timeout in seconds")
 	retry    = flag.Int("retry", 5, "Max number of attempts for DHCP clients to send requests. -1 means infinity")
 	verbose  = flag.Bool("verbose", false, "Verbose output")


### PR DESCRIPTION
Webboot now includes the WIFI feature. In order for WIFI
to work, it needs to append the iwconfig and iwlist when building
its initramfs to set parameters of network interface specific to
wireless operation and to see information about the interfaces.

Signed-off-by: Urvisha Patel <patelvisha2007@gmail.com>