### PR TITLE
Allow adding multiple u-root switches via -u

### DIFF
--- a/buildimage.go
+++ b/buildimage.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 var (
@@ -32,7 +33,7 @@ func main() {
 		{"go", "get", "-u", "github.com/u-root/u-root"},
 		{"go", "get", "-d", "-v", "-u", "github.com/u-root/NiChrome/..."},
 		{"sudo", "apt", "install", "wireless-tools"},
-		{"go", "run", "github.com/u-root/u-root/.", "-files", "/sbin/iwconfig:bin/iwconfig", "-files", "/sbin/iwlist:bin/iwlist", *uroot, *cmds, *wcmds, *ncmds},
+		append(append([]string{"go", "run", "github.com/u-root/u-root/.", "-files", "/sbin/iwconfig:bin/iwconfig", "-files", "/sbin/iwlist:bin/iwlist"}, strings.Fields(*uroot)...), *cmds, *wcmds, *ncmds),
 	}
 	for _, cmd := range commands {
 		debug("Run %v", cmd)


### PR DESCRIPTION
Currently, we can do this
go run . -u -build=bb
and u-root will build with busybox since the value of the -u switch
is passed to the u-root command.

If you have multiple space-separated flags to pass to u-root you
have to do this:
go run . -u "-build=bb some other flags"
because the -u switch applies to the next argument, not all arguments,
so you need to use "" to make it be one argument.

We can not do this:
go run . -u "-build=bb -files bzImage:bzImage"
because the switch will be passed to u-root as one
argument:
-build=bb -files bzImage:bzImage
not two
-build=bb
-files bzImage:bzImage

This change takes the value of the *uroot flag and applies
strings.Fields to it, correctly passing the arguments to the u-root
command.

Test via this command, before and after:
go run . -u '-build=bb -files bzImage:bzImage'
It did not used to work and does now.