### PR TITLE
Fix the print message

### DIFF
--- a/webboot/webboot.go
+++ b/webboot/webboot.go
@@ -115,7 +115,7 @@ func name(URL string) (string, error) {
 }
 
 func usage() {
-	log.Printf("Usage: %s [ARGS] URL or name of OS\n", os.Args[0])
+	log.Printf("Usage: %s [flags] URL or name of bookmark\n", os.Args[0])
 	flag.PrintDefaults()
 	os.Exit(1)
 }


### PR DESCRIPTION
Before, the usage function printed the wrong description: "webboot
[ARGS] URL or name of OS." ARGS is not the proper description as ARGS is
the URL or name of bookmark. Instead, it should say [flags] as flags describe
the optional parameters users can pass in.

User can attempt to type a name of OS or URL, but it is preferred if
they use one of the OSes in the bookmark webboot has or an URL.

Signed-off-by: Urvisha Patel <patelvisha2007@gmail.com>