### PR TITLE
Download ISO and save it in pmem device

### DIFF
--- a/webboot/webboot_test.go
+++ b/webboot/webboot_test.go
@@ -63,31 +63,6 @@ func TestName(t *testing.T) {
 
 }
 
-func TestWrite(t *testing.T) {
-	content := []byte("temporary file's content")
-	tmpDir, err := ioutil.TempDir("", "tmpDir")
-	if err != nil {
-		t.Fatalf("Failed to create a temporary directory")
-	}
-	tmpfile := filepath.Join(tmpDir, "tmpfile")
-	if err := ioutil.WriteFile(tmpfile, content, 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	file, err := os.Open(tmpfile)
-	if err != nil {
-		t.Fatalf("Failed to open %v: got %v, want nil", tmpfile, err)
-	}
-
-	testfn := filepath.Join(tmpDir, "testfile")
-	err = write(file, testfn)
-
-	read, err := ioutil.ReadFile(testfn)
-	if !bytes.Equal(content, read) {
-		t.Fatalf("Failed to write %v: got %v, want %v", testfn, string(read), string(content))
-	}
-}
-
 func TestLinkOpen(t *testing.T) {
 	tests := []test{
 		{name: "TinyCore", linkOrName: "http://tinycorelinux.net/10.x/x86_64/release/CorePure64-10.1.iso", md5link: "http://tinycorelinux.net/10.x/x86_64/release/CorePure64-10.1.iso.md5.txt"},


### PR DESCRIPTION
Store the ISO in pmem device that will be
carried across to the next kernel. This allows the next kernel to load
all of the packages for graphics and saves time from storing it
into a file for mounting when pmem device can be
used instead.

Signed-off-by: Urvisha Patel <patelvisha2007@gmail.com>