### PR TITLE
Mount persistent memory device on temp directory

### DIFF
--- a/webboot/webboot.go
+++ b/webboot/webboot.go
@@ -155,7 +155,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if err = mountkexec.MountISO(filename, tmp); err != nil {
+	if err = mountkexec.MountISOPmem("/dev/pmem0", tmp); err != nil {
 		log.Fatalf("Error in mountISO:%v", err)
 
 	}


### PR DESCRIPTION
Before, webboot stores the ISO into a file, which then was
mounted on a temporary directory. Now, webboot stores the ISO in a pmem
device, which will be mounted on a temporary directory instead.

Signed-off-by: Urvisha Patel <patelvisha2007@gmail.com>