### PR TITLE
Exit if invalid OS is specified 

### DIFF
--- a/webboot/webboot_test.go
+++ b/webboot/webboot_test.go
@@ -1,12 +1,9 @@
 package main
 
 import (
-	"bytes"
 	"crypto/md5"
 	"encoding/hex"
 	"io/ioutil"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -21,9 +18,7 @@ type test struct {
 
 func TestParseArg(t *testing.T) {
 	tests := []test{
-		{name: "Debian", linkOrName: "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-10.0.0-amd64-netinst.iso", expectedLink: "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-10.0.0-amd64-netinst.iso", expectedName: "debian-10.0.0-amd64-netinst.iso"},
-		{name: "TinyCore", linkOrName: "tinycore", expectedLink: "http://tinycorelinux.net/10.x/x86_64/release/CorePure64-10.1.iso", expectedName: "tinycore"},
-		{name: "Ubuntu", linkOrName: "http://releases.ubuntu.com/18.04.2/ubuntu-18.04.2-desktop-amd64.iso", expectedLink: "http://releases.ubuntu.com/18.04.2/ubuntu-18.04.2-desktop-amd64.iso", expectedName: "ubuntu-18.04.2-desktop-amd64.iso"},
+		{name: "TinyCore", linkOrName: "Tinycore", expectedLink: "http://tinycorelinux.net/10.x/x86_64/release/TinyCorePure64-10.1.iso", expectedName: "Tinycore"},
 	}
 
 	for _, v := range tests {
@@ -42,33 +37,12 @@ func TestParseArg(t *testing.T) {
 	}
 }
 
-func TestName(t *testing.T) {
-	tests := []test{
-		{name: "TinyCore", linkOrName: "http://tinycorelinux.net/10.x/x86_64/release/CorePure64-10.1.iso", expectedName: "CorePure64-10.1.iso"},
-		{name: "ArchLinux", linkOrName: "http://mirrors.edge.kernel.org/archlinux/iso/2019.08.01/archlinux-2019.08.01-x86_64.iso", expectedName: "archlinux-2019.08.01-x86_64.iso"},
-		{name: "Ubuntu", linkOrName: "http://releases.ubuntu.com/18.04.2/ubuntu-18.04.2-desktop-amd64.iso", expectedName: "ubuntu-18.04.2-desktop-amd64.iso"},
-		{name: "HtmlFile", linkOrName: "http://releases.ubuntu.com", expectedName: "index.html"},
-	}
-	for _, v := range tests {
-		t.Run(v.name, func(t *testing.T) {
-			filename, err := name(v.linkOrName)
-			if err != nil {
-				t.Fatalf("Looking up the file name for %v: got %v, want nil", v.linkOrName, err)
-			}
-			if strings.Compare(filename, v.expectedName) != 0 {
-				t.Errorf("Looking for name to generate for %v: got %v, want %v", v.linkOrName, filename, v.expectedName)
-			}
-		})
-	}
-
-}
-
 func TestLinkOpen(t *testing.T) {
 	tests := []test{
 		{name: "TinyCore", linkOrName: "http://tinycorelinux.net/10.x/x86_64/release/CorePure64-10.1.iso", md5link: "http://tinycorelinux.net/10.x/x86_64/release/CorePure64-10.1.iso.md5.txt"},
 		{name: "ArchLinux", linkOrName: "http://mirrors.edge.kernel.org/archlinux/iso/2019.08.01/archlinux-2019.08.01-x86_64.iso", md5link: "http://mirrors.edge.kernel.org/archlinux/iso/2019.08.01/md5sums.txt"},
-//		Ubuntu takes too long to download right now for testing purposes. Test fails due to the download and testing being too long.
-//		{name: "Ubuntu", linkOrName: "http://old-releases.ubuntu.com/releases/18.04.2/ubuntu-18.04.2-desktop-amd64.iso", md5link: "http://old-releases.ubuntu.com/releases/18.04.2/MD5SUMS"},
+		// Ubuntu takes too long to download right now for testing purposes. Test fails due to the download and testing being too long.
+		// {name: "Ubuntu", linkOrName: "http://old-releases.ubuntu.com/releases/18.04.2/ubuntu-18.04.2-desktop-amd64.iso", md5link: "http://old-releases.ubuntu.com/releases/18.04.2/MD5SUMS"},
 	}
 
 	for _, v := range tests {


### PR DESCRIPTION
If the user provides an unsupported OS, the program will exit and print all of the currently supported OSes.

Signed-off-by: Urvisha Patel <patelvisha2007@gmail.com>