### PR TITLE
Remove functions we do not need

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,10 @@ require (
 	github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065 // indirect
 	github.com/u-root/u-root v5.0.0+incompatible
 	github.com/vishvananda/netlink v1.1.0
+	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 // indirect
 	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb
 	golang.org/x/tools v0.0.0-20190709211700-7b25e351ac0e // indirect
 	google.golang.org/grpc v1.27.1 // indirect
+	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 	pack.ag/tftp v1.0.0
 )

--- a/pkg/mountkexec/mountkexec.go
+++ b/pkg/mountkexec/mountkexec.go
@@ -12,41 +12,9 @@ import (
 	"github.com/u-root/u-root/pkg/boot"
 	"github.com/u-root/u-root/pkg/boot/kexec"
 	"github.com/u-root/u-root/pkg/boot/multiboot"
-	"github.com/u-root/u-root/pkg/loop"
-	"github.com/u-root/u-root/pkg/mount"
 	"github.com/u-root/u-root/pkg/uio"
 	"github.com/u-root/webboot/pkg/webboot"
-	"golang.org/x/sys/unix"
 )
-
-// MountISO creates a directory and mounts an input iso on the directory.
-func MountISO(isoPath, mountDir string) error {
-	if err := os.MkdirAll(mountDir, 777); err != nil {
-		return fmt.Errorf("error making mount directory:%v", err)
-	}
-	loopDevice, err := loop.FindDevice()
-	if err != nil {
-		return fmt.Errorf("error finding loop device:%v", err)
-	}
-	if err := loop.SetFile(loopDevice, isoPath); err != nil {
-		return fmt.Errorf("error setting loop device:%v", err)
-	}
-	if _, err = mount.Mount(loopDevice, mountDir, "iso9660", "", unix.MS_RDONLY); err != nil {
-		return fmt.Errorf("error mounting ISO:%v", err)
-	}
-	return nil
-}
-
-// MountISOPmem creates a directory and mounts the pmem block device on the directory
-func MountISOPmem(pmem, mountDir string) error {
-	if err := os.MkdirAll(mountDir, 777); err != nil {
-		return fmt.Errorf("error making mount directory:%v", err)
-	}
-	if _, err := mount.Mount(pmem, mountDir, "iso9660", "", unix.MS_RDONLY); err != nil {
-		return fmt.Errorf("error mounting %v on %v: %v", pmem, mountDir, err)
-	}
-	return nil
-}
 
 // KexecISO boots up a new kernel and initramfs
 func KexecISO(opp *webboot.Distro, dir string) error {

--- a/webboot/webboot.go
+++ b/webboot/webboot.go
@@ -28,9 +28,11 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/u-root/u-root/pkg/mount"
 	"github.com/u-root/webboot/pkg/dhclient"
 	"github.com/u-root/webboot/pkg/mountkexec"
 	"github.com/u-root/webboot/pkg/webboot"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -227,8 +229,8 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if err = mountkexec.MountISOPmem("/dev/pmem0", tmp); err != nil {
-		log.Fatalf("Error in mountISO:%v", err)
+	if _, err := mount.Mount("/dev/pmem0", tmp, "iso9660", "", unix.MS_RDONLY|unix.MS_NOATIME); err != nil {
+		log.Fatal(err)
 
 	}
 	if *dryrun == false {


### PR DESCRIPTION
The various mount functions in mountkexec were doing work
we did not need. Remove them.

This is part of a larger project, to shrink the amount
of code in webboot we don't really need to write.