### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,3 +20,5 @@ require (
 	google.golang.org/grpc v1.27.1
 	pack.ag/tftp v1.0.0
 )
+
+replace github.com/u-root/webboot v0.0.0 => /gopath/github.com/u-root/webboot 


### PR DESCRIPTION
Let all imported internal pkg point to the local pkg file. So when the local pkg is modified, it can take effect immediately, without pushing to the remote repo first.
