### PR TITLE
Create the bootiso package

### DIFF
--- a/pkg/bootiso/bootiso.go
+++ b/pkg/bootiso/bootiso.go
@@ -23,6 +23,7 @@ func ParseConfigFromISO(isoPath string) ([]boot.OSImage, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Error creating mount dir: %v", err)
 	}
+	defer os.RemoveAll(tmp)
 
 	loopdev, err := loop.New(isoPath, "iso9660", "")
 	if err != nil {
@@ -68,6 +69,7 @@ func BootFromPmem(isoPath string, configLabel string) error {
 	if err != nil {
 		return fmt.Errorf("Error creating temp directory: %v", err)
 	}
+	defer os.RemoveAll(tmp)
 
 	if _, err := mount.Mount("/dev/pmem0", tmp, "iso9660", "", unix.MS_RDONLY|unix.MS_NOATIME); err != nil {
 		return fmt.Errorf("Error mounting pmem0 to temp directory: %v", err)

--- a/pkg/bootiso/bootiso.go
+++ b/pkg/bootiso/bootiso.go
@@ -1,0 +1,116 @@
+package bootiso
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/u-root/u-root/pkg/boot"
+	"github.com/u-root/u-root/pkg/boot/kexec"
+	"github.com/u-root/u-root/pkg/boot/syslinux"
+	"github.com/u-root/u-root/pkg/mount"
+	"github.com/u-root/u-root/pkg/mount/loop"
+	"golang.org/x/sys/unix"
+)
+
+// ParseConfigFromISO mounts an iso file to a
+// temp dir to get the config options
+func ParseConfigFromISO(isoPath string) ([]boot.OSImage, error) {
+	tmp, err := ioutil.TempDir("", "mnt")
+	if err != nil {
+		return nil, fmt.Errorf("Error creating mount dir: %v", err)
+	}
+
+	loopdev, err := loop.New(isoPath, "iso9660", "")
+	if err != nil {
+		return nil, fmt.Errorf("Error creating loop device: %v", err)
+	}
+
+	mp, err := loopdev.Mount(tmp, unix.MS_RDONLY|unix.MS_NOATIME)
+	if err != nil {
+		return nil, fmt.Errorf("Error mounting loop device: %v", err)
+	}
+	defer mp.Unmount(0)
+
+	configOpts, err := syslinux.ParseLocalConfig(context.Background(), tmp)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing config: %v", err)
+	}
+
+	return configOpts, nil
+}
+
+// BootFromPmem copies the ISO to pmem0 and boots
+// given the syslinux configuration with the provided label
+func BootFromPmem(isoPath string, configLabel string) error {
+	pmem, err := os.OpenFile("/dev/pmem0", os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return fmt.Errorf("Error opening persistent memory device: %v", err)
+	}
+
+	iso, err := os.Open(isoPath)
+	if err != nil {
+		return fmt.Errorf("Error opening ISO: %v", err)
+	}
+	defer iso.Close()
+
+	if _, err := io.Copy(pmem, iso); err != nil {
+		return fmt.Errorf("Error copying from ISO to pmem: %v", err)
+	}
+	if err = pmem.Close(); err != nil {
+		return fmt.Errorf("Error closing persistent memory device: %v", err)
+	}
+
+	tmp, err := ioutil.TempDir("", "mnt")
+	if err != nil {
+		return fmt.Errorf("Error creating temp directory: %v", err)
+	}
+
+	if _, err := mount.Mount("/dev/pmem0", tmp, "iso9660", "", unix.MS_RDONLY|unix.MS_NOATIME); err != nil {
+		return fmt.Errorf("Error mounting pmem0 to temp directory: %v", err)
+	}
+
+	configOpts, err := syslinux.ParseLocalConfig(context.Background(), tmp)
+	if err != nil {
+		return fmt.Errorf("Error retrieving syslinux config options: %v", err)
+	}
+
+	osImage := findConfigOptionByLabel(configOpts, configLabel)
+	if osImage == nil {
+		return fmt.Errorf("Config option with the requested label does not exist")
+	}
+
+	// Need to convert from boot.OSImage to boot.LinuxImage to edit the Cmdline
+	linuxImage, ok := osImage.(*boot.LinuxImage)
+	if !ok {
+		return fmt.Errorf("Error converting from boot.OSImage to boot.LinuxImage")
+	}
+
+	localCmd, err := ioutil.ReadFile("/proc/cmdline")
+	if err != nil {
+		return fmt.Errorf("Error accessing /proc/cmdline")
+	}
+	cmdline := strings.TrimSuffix(string(localCmd), "\n") + " " + linuxImage.Cmdline
+	linuxImage.Cmdline = cmdline
+
+	if err := linuxImage.Load(true); err != nil {
+		return err
+	}
+	if err := kexec.Reboot(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func findConfigOptionByLabel(configOptions []boot.OSImage, configLabel string) boot.OSImage {
+	for _, config := range configOptions {
+		if config.Label() == configLabel {
+			return config
+		}
+	}
+	return nil
+}

--- a/pkg/bootiso/bootiso_test.go
+++ b/pkg/bootiso/bootiso_test.go
@@ -1,0 +1,84 @@
+package bootiso
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"testing"
+)
+
+func TestParseConfigFromISO(t *testing.T) {
+	isoPath, err := getIsoPath()
+	if err != nil {
+		t.Error(err)
+	}
+
+	configOpts, err := ParseConfigFromISO(isoPath)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectedLabels := [4]string{
+		"Boot TinyCorePure64",
+		"Boot TinyCorePure64 (on slow devices, waitusb=5)",
+		"Boot Core (command line only).",
+		"Boot Core (command line only on slow devices, waitusb=5)",
+	}
+
+	for i, config := range configOpts {
+		if config.Label() != expectedLabels[i] {
+			t.Error("Invalid configuration option found.")
+		}
+	}
+}
+
+func downloadTestISO(isoPath string) error {
+	resp, err := http.Get("https://github.com/u-root/webboot-distro/raw/master/iso/tinycore/10.x/x86_64/release/TinyCorePure64.iso")
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP Get failed: %v", resp.StatusCode)
+	}
+
+	file, err := os.Create(isoPath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = io.Copy(file, resp.Body)
+	return err
+}
+
+func getIsoPath() (string, error) {
+	homedir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return homedir + "/TinyCorePure64.iso", nil
+}
+
+func TestMain(m *testing.M) {
+	// Need a test ISO at the home directory
+	isoPath, err := getIsoPath()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if _, err := os.Stat(isoPath); err == nil {
+		fmt.Println("ISO file was found.")
+	} else if os.IsNotExist(err) {
+		fmt.Print("No ISO found. Downloading...")
+		err := downloadTestISO(isoPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Print("DONE!\n")
+	}
+
+	os.Exit(m.Run())
+}

--- a/pkg/bootiso/bootiso_test.go
+++ b/pkg/bootiso/bootiso_test.go
@@ -1,20 +1,14 @@
 package bootiso
 
 import (
-	"fmt"
-	"io"
 	"log"
-	"net/http"
 	"os"
 	"testing"
 )
 
-func TestParseConfigFromISO(t *testing.T) {
-	isoPath, err := getIsoPath()
-	if err != nil {
-		t.Error(err)
-	}
+var isoPath string = "testdata/TinyCorePure64.iso"
 
+func TestParseConfigFromISO(t *testing.T) {
 	configOpts, err := ParseConfigFromISO(isoPath)
 	if err != nil {
 		t.Error(err)
@@ -34,50 +28,9 @@ func TestParseConfigFromISO(t *testing.T) {
 	}
 }
 
-func downloadTestISO(isoPath string) error {
-	resp, err := http.Get("https://github.com/u-root/webboot-distro/raw/master/iso/tinycore/10.x/x86_64/release/TinyCorePure64.iso")
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("HTTP Get failed: %v", resp.StatusCode)
-	}
-
-	file, err := os.Create(isoPath)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	_, err = io.Copy(file, resp.Body)
-	return err
-}
-
-func getIsoPath() (string, error) {
-	homedir, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return homedir + "/TinyCorePure64.iso", nil
-}
-
 func TestMain(m *testing.M) {
-	// Need a test ISO at the home directory
-	isoPath, err := getIsoPath()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if _, err := os.Stat(isoPath); err == nil {
-		fmt.Println("ISO file was found.")
-	} else if os.IsNotExist(err) {
-		fmt.Print("No ISO found. Downloading...")
-		err := downloadTestISO(isoPath)
-		if err != nil {
-			log.Fatal(err)
-		}
-		fmt.Print("DONE!\n")
+	if _, err := os.Stat(isoPath); err != nil {
+		log.Fatal("ISO file was not found in the testdata directory.")
 	}
 
 	os.Exit(m.Run())


### PR DESCRIPTION
Initial pull request for the bootiso package. Moves most of the logic from the original webboot to a separate package. Specifically, the `BootFromPmem()` function does the work of copying the ISO to pmem, setting up the bootable LinuxImage object, and calling `kexec()` on it.

We also added functionality to retrieve the syslinux configuration from an ISO file. This can allow the user to select the desired boot mode (ex. normal, command-line only, etc.)