### PR TITLE
Add wifi setup functionality

### DIFF
--- a/cmds/webboot/network.go
+++ b/cmds/webboot/network.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	ui "github.com/gizak/termui/v3"
+	"github.com/u-root/NiChrome/pkg/wifi"
+	"github.com/u-root/webboot/pkg/menu"
+	"github.com/vishvananda/netlink"
+)
+
+func connected() bool {
+	client := http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	if _, err := client.Get("http://google.com"); err != nil {
+		return false
+	}
+	return true
+}
+
+func interfaceEntries() ([]menu.Entry, error) {
+	interfaces, err := netlink.LinkList()
+	if err != nil {
+		return nil, err
+	}
+
+	var ifEntries []menu.Entry
+	for _, iface := range interfaces {
+		ifEntries = append(ifEntries, &Interface{label: iface.Attrs().Name})
+	}
+	return ifEntries, nil
+}
+
+func interfaceIsWireless(ifname string) bool {
+	devPath := fmt.Sprintf("/sys/class/net/%s/wireless", ifname)
+	if _, err := os.Stat(devPath); err != nil {
+		return false
+	}
+	return true
+}
+
+func setupNetwork(uiEvents <-chan ui.Event) error {
+	iface, err := selectNetworkInterface(uiEvents)
+	if err != nil {
+		return err
+	}
+
+	return selectWirelessNetwork(uiEvents, iface)
+}
+
+func selectNetworkInterface(uiEvents <-chan ui.Event) (string, error) {
+	ifEntries, err := interfaceEntries()
+	if err != nil {
+		return "", err
+	}
+
+	for {
+		iface, err := menu.DisplayMenu("Network Interfaces", "Choose an option", ifEntries, uiEvents)
+		if err != nil {
+			return "", err
+		}
+
+		if !interfaceIsWireless(iface.Label()) {
+			menu.DisplayResult([]string{"Only wireless network interfaces are supported."}, uiEvents)
+		} else {
+			return iface.Label(), nil
+		}
+	}
+}
+
+func selectWirelessNetwork(uiEvents <-chan ui.Event, iface string) error {
+	worker, err := wifi.NewIWLWorker(iface)
+	if err != nil {
+		return err
+	}
+
+	for {
+		networkScan, err := worker.Scan()
+		if err != nil {
+			return err
+		}
+
+		netEntries := []menu.Entry{}
+		for _, network := range networkScan {
+			netEntries = append(netEntries, &Network{info: network})
+		}
+
+		entry, err := menu.DisplayMenu("Wireless Networks", "Choose an option", netEntries, uiEvents)
+		if err != nil {
+			return err
+		}
+
+		network, ok := entry.(*Network)
+		if !ok {
+			return fmt.Errorf("Bad menu entry.")
+		}
+
+		if err := connectWirelessNetwork(uiEvents, worker, network.info); err != nil {
+			menu.DisplayResult([]string{err.Error()}, uiEvents)
+			continue
+		}
+
+		return nil
+	}
+}
+
+func connectWirelessNetwork(uiEvents <-chan ui.Event, worker wifi.WiFi, network wifi.Option) error {
+	var setupParams = []string{network.Essid}
+	authSuite := network.AuthSuite
+
+	if authSuite == wifi.NotSupportedProto {
+		return fmt.Errorf("Security protocol is not supported.")
+	} else if authSuite == wifi.WpaPsk || authSuite == wifi.WpaEap {
+		credentials, err := enterCredentials(uiEvents, authSuite)
+		if err != nil {
+			return err
+		}
+		setupParams = append(setupParams, credentials...)
+	}
+
+	if err := worker.Connect(setupParams...); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func enterCredentials(uiEvents <-chan ui.Event, authSuite wifi.SecProto) ([]string, error) {
+	var credentials []string
+	pass, err := menu.NewInputWindow("Enter password:", menu.AlwaysValid, uiEvents)
+	if err != nil {
+		return nil, err
+	}
+
+	credentials = append(credentials, pass)
+	if authSuite == wifi.WpaPsk {
+		return credentials, nil
+	}
+
+	// If not WpaPsk, the network uses WpaEap and also needs an identity
+	identity, err := menu.NewInputWindow("Enter identity:", menu.AlwaysValid, uiEvents)
+	if err != nil {
+		return nil, err
+	}
+
+	credentials = append(credentials, identity)
+	return credentials, nil
+}

--- a/cmds/webboot/types.go
+++ b/cmds/webboot/types.go
@@ -1,6 +1,11 @@
 package main
+ 
+import (
+	"fmt"
 
-import "github.com/u-root/webboot/pkg/menu"
+	"github.com/u-root/NiChrome/pkg/wifi"
+	"github.com/u-root/webboot/pkg/menu"
+)
 
 const (
 	tcURL    = "http://tinycorelinux.net/10.x/x86_64/release/TinyCorePure64-10.1.iso"
@@ -61,6 +66,32 @@ var _ = menu.Entry(&DirOption{})
 // Label is the string this option displays in the menu page.
 func (d *DirOption) Label() string {
 	return d.label
+}
+
+type Interface struct {
+	label string
+}
+
+func (i *Interface) Label() string {
+	return i.label
+}
+
+type Network struct {
+	info wifi.Option
+}
+
+func (n *Network) Label() string {
+	switch n.info.AuthSuite {
+	case wifi.NoEnc:
+		return fmt.Sprintf("%s: No Passphrase\n", n.info.Essid)
+	case wifi.WpaPsk:
+		return fmt.Sprintf("%s: WPA-PSK (only passphrase)\n", n.info.Essid)
+	case wifi.WpaEap:
+		return fmt.Sprintf("%s: WPA-EAP (passphrase and identity)\n", n.info.Essid)
+	case wifi.NotSupportedProto:
+		return fmt.Sprintf("%s: Not a supported protocol\n", n.info.Essid)
+	}
+	return "Invalid wifi network."
 }
 
 // BackOption let user back to the upper menu

--- a/cmds/webboot/utils.go
+++ b/cmds/webboot/utils.go
@@ -8,10 +8,6 @@ import (
 	"net/url"
 	"os"
 	"strings"
-
-	ui "github.com/gizak/termui/v3"
-	"github.com/u-root/webboot/pkg/dhclient"
-	"github.com/u-root/webboot/pkg/menu"
 )
 
 // WriteCounter counts the number of bytes written to it. It implements to the io.Writer
@@ -69,41 +65,4 @@ func download(URL, fPath string) error {
 	fmt.Println("\nDone!")
 	verbose("%q is downloaded at %q\n", URL, fPath)
 	return nil
-}
-
-//	-ifName:  Name of the interface
-//	-timeout: Lease timeout in seconds
-//	-retry:   Number of DHCP renewals before exiting
-//	-verbose: Verbose mode
-//	-ipv4:    Use IPV4
-//	-ipv6:    Use IPV6
-func setUpNetwork(uiEvents <-chan ui.Event) (bool, error) {
-
-	isIfName := func(input string) (string, string, bool) {
-		if input[0] == 'e' || input[0] == 'w' {
-			return input, "", true
-		}
-		return "", "not a valid interface name", false
-	}
-
-	ifName, err := menu.NewInputWindow("Enter name of the interface:", isIfName, uiEvents)
-	if err != nil {
-		return false, err
-	}
-
-	cl := make(chan string)
-	go dhclient.Request(ifName, 15, 5, *v, true, true, cl)
-	for {
-		msg, ok := <-cl
-		if !ok {
-			return false, nil
-		}
-		if msg == "Successful" {
-			menu.DisplayResult([]string{msg}, uiEvents)
-			return true, nil
-		}
-		if _, err := menu.DisplayResult([]string{msg}, uiEvents); err != nil {
-			return false, err
-		}
-	}
 }


### PR DESCRIPTION
Add a menu system for setting up a wifi connection. Most of the back-end functionality for configuring the connection comes from [NiChrome's wifi package](https://github.com/u-root/NiChrome/tree/master/pkg/wifi).

We need to collect the following from the user in order to set up the network:

- Wireless network interface
- Wifi network name (ESSID)
- Login credentials for the wifi network

Most of the new logic is contained in the new `network.go` file, but we also modified the following:

- `types.go` in order to add menu entry classes for Interface and Network
- `webboot.go` to change the network setup function from the old `setUpNetwork()` to the new `setupNetwork()`
- `utils.go` to remove the old `setUpNetwork()` function

