### PR TITLE
Display Bookmarks

### DIFF
--- a/cmds/webboot/types.go
+++ b/cmds/webboot/types.go
@@ -13,6 +13,8 @@ var bookmarks = map[string]string{
 	"TinyCorePure64.iso":      wbtcpURL,
 }
 
+var bookmarkList string
+
 // ISO contains information of the iso user want to boot
 type ISO struct {
 	label string

--- a/cmds/webboot/webboot.go
+++ b/cmds/webboot/webboot.go
@@ -64,26 +64,29 @@ func (d *DownloadOption) exec(uiEvents <-chan ui.Event, network bool, cacheDir s
 	}
 	validIsoName := func(input string) (string, string, bool) {
 		re := regexp.MustCompile(`[\w]+.iso`)
-		if input == "" || re.Match([]byte(input)) {
+		if input == "" {
+			return "", bookmarkList, false
+		}
+		if re.Match([]byte(input)) {
 			return input, "", true
 		}
 		return "", "File name should only contain [a-zA-Z0-9_], and should end in .iso", false
 	}
-	filename, err := menu.NewInputWindow("Enter ISO name (Enter an empty string to go back):", validIsoName, uiEvents)
+	filename, err := menu.NewInputWindow("Enter ISO name (Enter <Esc> to go back):", validIsoName, uiEvents)
 	if err != nil {
 		return nil, err
 	}
-	if filename == "" {
+	if filename == "<Esc>" {
 		return &BackOption{}, nil
 	}
 
 	link, ok := bookmarks[filename]
 	if !ok {
-		if link, err = menu.NewInputWindow("Enter URL (Enter an empty string to go back):", menu.AlwaysValid, uiEvents); err != nil {
+		if link, err = menu.NewInputWindow("Enter URL (Enter <Esc> to go back):", menu.AlwaysValid, uiEvents); err != nil {
 			return nil, err
 		}
 	}
-	if link == "" {
+	if link == "<Esc>" {
 		return &BackOption{}, nil
 	}
 
@@ -192,6 +195,12 @@ func main() {
 	if *v {
 		verbose = log.Printf
 	}
+
+	bookmarkList = "We provide these isos' link:"
+	for key := range bookmarks {
+		bookmarkList += "\n" + key
+	}
+
 	cacheDir := *dir
 	if _, err := os.Stat(cacheDir); os.IsNotExist(err) {
 		menu.DisplayResult([]string{fmt.Sprintf("the cache dir %v does not exist", cacheDir)}, ui.PollEvents())

--- a/cmds/webboot/webboot_test.go
+++ b/cmds/webboot/webboot_test.go
@@ -171,11 +171,11 @@ func TestBackOptionInDownload(t *testing.T) {
 	}{
 		{
 			name:  "go_back_from_input_iso_name",
-			input: []string{"<Enter>"},
+			input: []string{"<Escape>"},
 		},
 		{
 			name:  "go_back_from_input_url",
-			input: []string{"a", ".", "i", "s", "o", "<Enter>", "<Enter>"},
+			input: []string{"a", ".", "i", "s", "o", "<Enter>", "<Escape>"},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/menu/menu.go
+++ b/pkg/menu/menu.go
@@ -67,7 +67,7 @@ func processInput(introwords string, location int, wid int, ht int, isValid vali
 	location += 2
 	input := newParagraph("", true, location, wid, ht+2)
 	location += ht + 2
-	warning := newParagraph("", false, location, wid, 3)
+	warning := newParagraph("", false, location, wid, 15)
 
 	ui.Render(intro)
 	ui.Render(input)
@@ -95,6 +95,8 @@ func processInput(introwords string, location int, wid int, ht int, isValid vali
 				input.Text = input.Text[:len(input.Text)-1]
 				ui.Render(input)
 			}
+		case "<Escape>":
+			return "<Esc>", "", nil
 		case "<Space>":
 			input.Text += " "
 			ui.Render(input)


### PR DESCRIPTION
Display bookmark list  in the warning when enter empty string in entering iso name step. Change the go back button from empty string to press Escape key.

This is a demo of displaying bookmarks and using <Esc> to go back.
![cinnamon-20200818-6](https://user-images.githubusercontent.com/11041619/90574934-0b92a200-e16f-11ea-8a8d-1d10f77dc02d.gif)

Signed-off-by: April Xu <shiyux@google.com>