### PR TITLE
Include tests for menu and webboot in the Travis test script.

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -8,4 +8,6 @@ if [ ! -f "/tmp/initramfs.linux_amd64.cpio" ]; then
     exit 1
 fi
 
+(cd cmds/webboot && go test -v)
+(cd pkg/menu && go test -v)
 (cd pkg/bootiso && sudo -E env "PATH=$PATH" go test -v) # need sudo to mount the test iso


### PR DESCRIPTION
The current test script that Travis runs checks the following:

- Does `webboot` build
- Was an initrams generated
- Run unit tests for the `bootiso` package

This PR adds the following checks:

- Run unit tests for `webboot`
- Run unit tests for the `menu` package