### PR TITLE
Avoid closing UI and showing output from the command line.

### DIFF
--- a/cmds/webboot/webboot.go
+++ b/cmds/webboot/webboot.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -233,9 +234,9 @@ func main() {
 	}
 	defer menu.Close()
 
-	// Suppress output, else it might overlap with the menu
-	log.SetOutput(ioutil.Discard)
-	os.Stdout = nil
+	// Buffer the log output, else it might overlap with the menu
+	var logBuffer bytes.Buffer
+	log.SetOutput(&logBuffer)
 
 	entry := getMainMenu(cacheDir)
 

--- a/cmds/webboot/webboot.go
+++ b/cmds/webboot/webboot.go
@@ -227,6 +227,16 @@ func main() {
 			cacheDir = cachePath
 		}
 	}
+
+	if err := menu.Init(); err != nil {
+		log.Fatalf(err.Error())
+	}
+	defer menu.Close()
+
+	// Suppress output, else it might overlap with the menu
+	log.SetOutput(ioutil.Discard)
+	os.Stdout = nil
+
 	entry := getMainMenu(cacheDir)
 
 	var err error

--- a/pkg/menu/menu.go
+++ b/pkg/menu/menu.go
@@ -37,6 +37,18 @@ func max(a, b int) int {
 	return b
 }
 
+func Init() error {
+	return ui.Init()
+}
+
+func Clear() {
+	ui.Clear()
+}
+
+func Close() {
+	ui.Close()
+}
+
 // AlwaysValid is a special isValid function that check nothing
 func AlwaysValid(input string) (string, string, bool) {
 	return input, "", true
@@ -119,27 +131,18 @@ func NewInputWindow(introwords string, isValid validCheck, uiEvents <-chan ui.Ev
 
 // NewCustomInputWindow creates a new ui window and displays an input box.
 func NewCustomInputWindow(introwords string, wid int, ht int, isValid validCheck, uiEvents <-chan ui.Event) (string, error) {
-	if err := ui.Init(); err != nil {
-		return "", fmt.Errorf("Failed to initialize termui: %v", err)
-	}
-	defer ui.Close()
-
+	defer ui.Clear()
 	input, _, err := processInput(introwords, 0, wid, ht, isValid, uiEvents)
-
 	return input, err
 }
 
 // DisplayResult opens a new window and displays a message.
 // each item in the message array will be displayed on a single line.
 func DisplayResult(message []string, uiEvents <-chan ui.Event) (string, error) {
-	if err := ui.Init(); err != nil {
-		return "", fmt.Errorf("Failed to initialize termui: %v", err)
-	}
-	defer ui.Close()
-
-	var wid int = resultWidth
+	defer ui.Clear()
 
 	// if a message is longer then width of the window, split it to shorter lines
+	var wid int = resultWidth
 	text := []string{}
 	for _, m := range message {
 		for len(m) > wid {
@@ -297,13 +300,10 @@ func parsingMenuOption(labels []string, menu *widgets.List, input, warning *widg
 // for example the wifi menu want to show specific warning when user hit a specific entry,
 // because some wifi's type may not be supported.
 func DisplayMenu(menuTitle string, introwords string, entries []Entry, uiEvents <-chan ui.Event, customWarning ...string) (Entry, error) {
-	if err := ui.Init(); err != nil {
-		return nil, fmt.Errorf("Failed to initialize termui: %v", err)
-	}
-	defer ui.Close()
+	defer ui.Clear()
+
 	// listData contains all choice's labels
 	listData := []string{}
-
 	for i, e := range entries {
 		listData = append(listData, fmt.Sprintf("[%d] %s", i, e.Label()))
 	}

--- a/pkg/menu/menu.go
+++ b/pkg/menu/menu.go
@@ -41,10 +41,6 @@ func Init() error {
 	return ui.Init()
 }
 
-func Clear() {
-	ui.Clear()
-}
-
 func Close() {
 	ui.Close()
 }

--- a/pkg/wifi/iwl.go
+++ b/pkg/wifi/iwl.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -154,12 +155,14 @@ func (w *IWLWorker) Connect(a ...string) error {
 	// it's been almost instantaneous. But, further, it needs to keep running.
 	go func() {
 		cmd := exec.CommandContext(ctx, "wpa_supplicant", "-i"+w.Interface, "-c/tmp/wifi.conf")
+		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr //For an easier time debugging
 		cmd.Run()
 	}()
 
 	// dhclient might never return on incorrect passwords or identity
 	go func() {
 		cmd := exec.CommandContext(ctx, "dhclient", "-ipv4=true", "-ipv6=false", "-v", w.Interface)
+		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr //For an easier time debugging
 		if err := cmd.Run(); err != nil {
 			c <- err
 		} else {

--- a/pkg/wifi/iwl.go
+++ b/pkg/wifi/iwl.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -155,14 +154,12 @@ func (w *IWLWorker) Connect(a ...string) error {
 	// it's been almost instantaneous. But, further, it needs to keep running.
 	go func() {
 		cmd := exec.CommandContext(ctx, "wpa_supplicant", "-i"+w.Interface, "-c/tmp/wifi.conf")
-		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr //For an easier time debugging
 		cmd.Run()
 	}()
 
 	// dhclient might never return on incorrect passwords or identity
 	go func() {
 		cmd := exec.CommandContext(ctx, "dhclient", "-ipv4=true", "-ipv6=false", "-v", w.Interface)
-		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr //For an easier time debugging
 		if err := cmd.Run(); err != nil {
 			c <- err
 		} else {


### PR DESCRIPTION
One issue with the UI was that when menu screens changed, output from the command line sometimes showed up on screen. This might be confusing to a user, who might think that the program crashed.

Avoiding this required 2 changes:

1. Only initialize and close termui once. If we need to change screens, call termui's `Clear()` function.
2. Supress output from `log` and `fmt`. Even if we avoid closing termui, text from the output can still overlap with the menu.

With this change applied, menu screens will hang when the user makes a selection that triggers a long-running operation (ex. wifi scanning, downloading). The next PR will include a loading animation that runs during these operations.