### PR TITLE
Buffer output from the wifi Connect() function.

### DIFF
--- a/cmds/webboot/webboot.go
+++ b/cmds/webboot/webboot.go
@@ -52,7 +52,7 @@ func (i *ISO) exec(uiEvents <-chan ui.Event, boot bool) error {
 // if this iso is existed in the bookmark, use it's url
 // elsewise ask for a download link
 func (d *DownloadOption) exec(uiEvents <-chan ui.Event, network bool, cacheDir string) (menu.Entry, error) {
-	if network /*&& !connected()*/ {
+	if network && !connected() {
 		if err := setupNetwork(uiEvents); err != nil {
 			return nil, err
 		}

--- a/cmds/webboot/webboot.go
+++ b/cmds/webboot/webboot.go
@@ -52,7 +52,7 @@ func (i *ISO) exec(uiEvents <-chan ui.Event, boot bool) error {
 // if this iso is existed in the bookmark, use it's url
 // elsewise ask for a download link
 func (d *DownloadOption) exec(uiEvents <-chan ui.Event, network bool, cacheDir string) (menu.Entry, error) {
-	if network && !connected() {
+	if network /*&& !connected()*/ {
 		if err := setupNetwork(uiEvents); err != nil {
 			return nil, err
 		}

--- a/pkg/wifi/iwl.go
+++ b/pkg/wifi/iwl.go
@@ -5,10 +5,10 @@
 package wifi
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -155,14 +155,16 @@ func (w *IWLWorker) Connect(a ...string) error {
 	// it's been almost instantaneous. But, further, it needs to keep running.
 	go func() {
 		cmd := exec.CommandContext(ctx, "wpa_supplicant", "-i"+w.Interface, "-c/tmp/wifi.conf")
-		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr //For an easier time debugging
+		var outBuffer, errBuffer bytes.Buffer
+		cmd.Stdout, cmd.Stderr = &outBuffer, &errBuffer //For an easier time debugging
 		cmd.Run()
 	}()
 
 	// dhclient might never return on incorrect passwords or identity
 	go func() {
 		cmd := exec.CommandContext(ctx, "dhclient", "-ipv4=true", "-ipv6=false", "-v", w.Interface)
-		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr //For an easier time debugging
+		var outBuffer, errBuffer bytes.Buffer
+		cmd.Stdout, cmd.Stderr = &outBuffer, &errBuffer //For an easier time debugging
 		if err := cmd.Run(); err != nil {
 			c <- err
 		} else {

--- a/pkg/wifi/iwl.go
+++ b/pkg/wifi/iwl.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os/exec"
 	"regexp"
@@ -54,19 +55,26 @@ type IWLWorker struct {
 	Interface string
 }
 
-func NewIWLWorker(i string) (WiFi, error) {
-	if o, err := exec.Command("ip", "link", "set", "dev", i, "up").CombinedOutput(); err != nil {
-		return &IWLWorker{""}, fmt.Errorf("ip link set dev %v up: %v (%v)", i, string(o), err)
+func NewIWLWorker(stdout, stderr io.Writer, i string) (WiFi, error) {
+	cmd := exec.Command("ip", "link", "set", "dev", i, "up")
+	cmd.Stdout, cmd.Stderr = stdout, stderr
+	if err := cmd.Run(); err != nil {
+		return &IWLWorker{""}, err
 	}
 	return &IWLWorker{i}, nil
 }
 
-func (w *IWLWorker) Scan() ([]Option, error) {
-	o, err := exec.Command("iwlist", w.Interface, "scanning").CombinedOutput()
-	if err != nil {
-		return nil, fmt.Errorf("iwlist: %v (%v)", string(o), err)
+func (w *IWLWorker) Scan(stdout, stderr io.Writer) ([]Option, error) {
+	// Need a local copy of exec's output to parse out the Iwlist
+	var execOutput bytes.Buffer
+	stdoutTee := io.MultiWriter(&execOutput, stdout)
+
+	cmd := exec.Command("iwlist", w.Interface, "scanning")
+	cmd.Stdout, cmd.Stderr = stdoutTee, stderr
+	if err := cmd.Run(); err != nil {
+		return nil, err
 	}
-	return parseIwlistOut(o), nil
+	return parseIwlistOut(execOutput.Bytes()), nil
 }
 
 /*
@@ -127,15 +135,19 @@ func parseIwlistOut(o []byte) []Option {
 	return res
 }
 
-func (w *IWLWorker) GetID() (string, error) {
-	o, err := exec.Command("iwgetid", "-r").CombinedOutput()
-	if err != nil {
+func (w *IWLWorker) GetID(stdout, stderr io.Writer) (string, error) {
+	var execOutput bytes.Buffer
+	stdoutTee := io.MultiWriter(&execOutput, stdout)
+
+	cmd := exec.Command("iwgetid", "-r")
+	cmd.Stdout, cmd.Stderr = stdoutTee, stderr
+	if err := cmd.Run(); err != nil {
 		return "", err
 	}
-	return strings.Trim(string(o), " \n"), nil
+	return strings.Trim(execOutput.String(), " \n"), nil
 }
 
-func (w *IWLWorker) Connect(a ...string) error {
+func (w *IWLWorker) Connect(stdout, stderr io.Writer, a ...string) error {
 	// format of a: [essid, pass, id]
 	conf, err := generateConfig(a...)
 	if err != nil {
@@ -155,16 +167,14 @@ func (w *IWLWorker) Connect(a ...string) error {
 	// it's been almost instantaneous. But, further, it needs to keep running.
 	go func() {
 		cmd := exec.CommandContext(ctx, "wpa_supplicant", "-i"+w.Interface, "-c/tmp/wifi.conf")
-		var outBuffer, errBuffer bytes.Buffer
-		cmd.Stdout, cmd.Stderr = &outBuffer, &errBuffer //For an easier time debugging
+		cmd.Stdout, cmd.Stderr = stdout, stderr
 		cmd.Run()
 	}()
 
 	// dhclient might never return on incorrect passwords or identity
 	go func() {
 		cmd := exec.CommandContext(ctx, "dhclient", "-ipv4=true", "-ipv6=false", "-v", w.Interface)
-		var outBuffer, errBuffer bytes.Buffer
-		cmd.Stdout, cmd.Stderr = &outBuffer, &errBuffer //For an easier time debugging
+		cmd.Stdout, cmd.Stderr = stdout, stderr
 		if err := cmd.Run(); err != nil {
 			c <- err
 		} else {

--- a/pkg/wifi/native.go
+++ b/pkg/wifi/native.go
@@ -6,6 +6,7 @@ package wifi
 
 import (
 	"fmt"
+	"io"
 	"syscall"
 	"unsafe"
 )
@@ -16,7 +17,7 @@ type NativeWorker struct {
 	Range     IWRange
 }
 
-func NewNativeWorker(i string) (WiFi, error) {
+func NewNativeWorker(stdout, stderr io.Writer, i string) (WiFi, error) {
 	s, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_DGRAM, syscall.IPPROTO_IP)
 	if err != nil {
 		return nil, err
@@ -24,15 +25,15 @@ func NewNativeWorker(i string) (WiFi, error) {
 	return &NativeWorker{FD: s, Interface: i}, nil
 }
 
-func (w *NativeWorker) Scan() ([]Option, error) {
+func (w *NativeWorker) Scan(stdout, stderr io.Writer) ([]Option, error) {
 	return nil, fmt.Errorf("Not Yet")
 }
 
-func (w *NativeWorker) GetID() (string, error) {
+func (w *NativeWorker) GetID(stdout, stderr io.Writer) (string, error) {
 	return "", fmt.Errorf("Not Yet")
 }
 
-func (w *NativeWorker) Connect(a ...string) error {
+func (w *NativeWorker) Connect(stdout, stderr io.Writer, a ...string) error {
 	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, uintptr(w.FD), SIOCGIWRANGE, uintptr(unsafe.Pointer(&w.Range)))
 	return err
 }

--- a/pkg/wifi/native_test.go
+++ b/pkg/wifi/native_test.go
@@ -5,6 +5,7 @@
 package wifi
 
 import (
+	"bytes"
 	"testing"
 )
 
@@ -12,13 +13,14 @@ func TestNative(t *testing.T) {
 	// Some things may fail as there may be no wlan or we might not
 	// have the right privs. So just bail out of the test if some early
 	// ops fail.
-	w, err := NewNativeWorker("wlan0")
+	var stdout, stderr bytes.Buffer
+	w, err := NewNativeWorker(&stdout, &stderr, "wlan0")
 	if err != nil {
 		t.Log(err)
 		return
 	}
 	t.Logf("Native is %v", w)
-	err = w.Connect()
+	err = w.Connect(&stdout, &stderr)
 	if err != nil {
 		t.Log(err)
 		return

--- a/pkg/wifi/stub.go
+++ b/pkg/wifi/stub.go
@@ -4,6 +4,8 @@
 
 package wifi
 
+import "io"
+
 var _ = WiFi(&StubWorker{})
 
 type StubWorker struct {
@@ -11,18 +13,18 @@ type StubWorker struct {
 	ID      string
 }
 
-func (w *StubWorker) Scan() ([]Option, error) {
+func NewStubWorker(stdout, stderr io.Writer, id string, options ...Option) (WiFi, error) {
+	return &StubWorker{ID: id, Options: options}, nil
+}
+
+func (w *StubWorker) Scan(stdout, stderr io.Writer) ([]Option, error) {
 	return w.Options, nil
 }
 
-func (w *StubWorker) GetID() (string, error) {
+func (w *StubWorker) GetID(stdout, stderr io.Writer) (string, error) {
 	return w.ID, nil
 }
 
-func (*StubWorker) Connect(a ...string) error {
+func (*StubWorker) Connect(stdout, stderr io.Writer, a ...string) error {
 	return nil
-}
-
-func NewStubWorker(id string, options ...Option) (WiFi, error) {
-	return &StubWorker{ID: id, Options: options}, nil
 }

--- a/pkg/wifi/types.go
+++ b/pkg/wifi/types.go
@@ -4,13 +4,15 @@
 
 package wifi
 
+import "io"
+
 type Option struct {
 	Essid     string
 	AuthSuite SecProto
 }
 
 type WiFi interface {
-	Scan() ([]Option, error)
-	GetID() (string, error)
-	Connect(a ...string) error
+	Scan(stdout, stderr io.Writer) ([]Option, error)
+	GetID(stdout, stderr io.Writer) (string, error)
+	Connect(stdout, stderr io.Writer, a ...string) error
 }


### PR DESCRIPTION
`wifi.Connect()` executes 2 shell commands and redirects the output to Stdout/Stderr. This output tends to overlap with the UI, so we would like to avoid showing it.

In this PR, we store the output from the commands in a `bytes.Buffer`. This allows us to keep it for later access, while keeping it from messing up the UI.