### PR TITLE
Initialize UI once and change screens using Clear()

### DIFF
--- a/cmds/webboot/webboot.go
+++ b/cmds/webboot/webboot.go
@@ -205,6 +205,7 @@ func getMainMenu(cacheDir string) menu.Entry {
 }
 
 func main() {
+
 	flag.Parse()
 	if *v {
 		verbose = log.Printf
@@ -227,6 +228,12 @@ func main() {
 			cacheDir = cachePath
 		}
 	}
+
+	if err := menu.Init(); err != nil {
+		log.Fatalf(err.Error())
+	}
+	defer menu.Close()
+
 	entry := getMainMenu(cacheDir)
 
 	var err error

--- a/pkg/menu/menu.go
+++ b/pkg/menu/menu.go
@@ -38,6 +38,14 @@ func max(a, b int) int {
 	return b
 }
 
+func Init() error {
+	return ui.Init()
+}
+
+func Close() {
+	ui.Close()
+}
+
 // AlwaysValid is a special isValid function that check nothing
 func AlwaysValid(input string) (string, string, bool) {
 	return input, "", true
@@ -120,27 +128,18 @@ func NewInputWindow(introwords string, isValid validCheck, uiEvents <-chan ui.Ev
 
 // NewCustomInputWindow creates a new ui window and displays an input box.
 func NewCustomInputWindow(introwords string, wid int, ht int, isValid validCheck, uiEvents <-chan ui.Event) (string, error) {
-	if err := ui.Init(); err != nil {
-		return "", fmt.Errorf("Failed to initialize termui: %v", err)
-	}
-	defer ui.Close()
-
+	defer ui.Clear()
 	input, _, err := processInput(introwords, 0, wid, ht, isValid, uiEvents)
-
 	return input, err
 }
 
 // DisplayResult opens a new window and displays a message.
 // each item in the message array will be displayed on a single line.
 func DisplayResult(message []string, uiEvents <-chan ui.Event) (string, error) {
-	if err := ui.Init(); err != nil {
-		return "", fmt.Errorf("Failed to initialize termui: %v", err)
-	}
-	defer ui.Close()
-
-	var wid int = resultWidth
+	defer ui.Clear()
 
 	// if a message is longer then width of the window, split it to shorter lines
+	var wid int = resultWidth
 	text := []string{}
 	for _, m := range message {
 		for len(m) > wid {
@@ -298,13 +297,10 @@ func parsingMenuOption(labels []string, menu *widgets.List, input, warning *widg
 // for example the wifi menu want to show specific warning when user hit a specific entry,
 // because some wifi's type may not be supported.
 func DisplayMenu(menuTitle string, introwords string, entries []Entry, uiEvents <-chan ui.Event, customWarning ...string) (Entry, error) {
-	if err := ui.Init(); err != nil {
-		return nil, fmt.Errorf("Failed to initialize termui: %v", err)
-	}
-	defer ui.Close()
+	defer ui.Clear()
+
 	// listData contains all choice's labels
 	listData := []string{}
-
 	for i, e := range entries {
 		listData = append(listData, fmt.Sprintf("[%d] %s", i, e.Label()))
 	}
@@ -331,6 +327,7 @@ func DisplayMenu(menuTitle string, introwords string, entries []Entry, uiEvents 
 	if err != nil {
 		return nil, fmt.Errorf("Fail to get the choose from menu: %+v", err)
 	}
+
 	return entries[chooseIndex], nil
 }
 


### PR DESCRIPTION
Originally, each widget in the `menu` package would call `termui.Init()` to render itself and then call `termui.Close()` at the end. This implemented the intended effect of changing screens, but a better way would be to initialize termui once and use `termui.Clear()` each time we want to clear the screen. This PR makes the change from the former method to the latter.