### PR TITLE
Renamed NewInputWindow() and DisplayMenu()

### DIFF
--- a/cmds/webboot/network.go
+++ b/cmds/webboot/network.go
@@ -66,7 +66,7 @@ func selectNetworkInterface(uiEvents <-chan ui.Event) (string, error) {
 	}
 
 	for {
-		iface, err := menu.DisplayMenu("Network Interfaces", "Choose an option", ifEntries, uiEvents)
+		iface, err := menu.PromptMenuEntry("Network Interfaces", "Choose an option", ifEntries, uiEvents)
 		if err != nil {
 			return "", err
 		}
@@ -96,7 +96,7 @@ func selectWirelessNetwork(uiEvents <-chan ui.Event, iface string) error {
 			netEntries = append(netEntries, &Network{info: network})
 		}
 
-		entry, err := menu.DisplayMenu("Wireless Networks", "Choose an option", netEntries, uiEvents)
+		entry, err := menu.PromptMenuEntry("Wireless Networks", "Choose an option", netEntries, uiEvents)
 		if err != nil {
 			return err
 		}
@@ -138,7 +138,7 @@ func connectWirelessNetwork(uiEvents <-chan ui.Event, worker wifi.WiFi, network 
 
 func enterCredentials(uiEvents <-chan ui.Event, authSuite wifi.SecProto) ([]string, error) {
 	var credentials []string
-	pass, err := menu.NewInputWindow("Enter password:", menu.AlwaysValid, uiEvents)
+	pass, err := menu.PromptTextInput("Enter password:", menu.AlwaysValid, uiEvents)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +149,7 @@ func enterCredentials(uiEvents <-chan ui.Event, authSuite wifi.SecProto) ([]stri
 	}
 
 	// If not WpaPsk, the network uses WpaEap and also needs an identity
-	identity, err := menu.NewInputWindow("Enter identity:", menu.AlwaysValid, uiEvents)
+	identity, err := menu.PromptTextInput("Enter identity:", menu.AlwaysValid, uiEvents)
 	if err != nil {
 		return nil, err
 	}

--- a/cmds/webboot/webboot.go
+++ b/cmds/webboot/webboot.go
@@ -41,7 +41,7 @@ func (i *ISO) exec(uiEvents <-chan ui.Event, boot bool) error {
 	for _, config := range configs {
 		entries = append(entries, &Config{label: config.Label()})
 	}
-	c, err := menu.DisplayMenu("Configs", "Choose an option", entries, uiEvents)
+	c, err := menu.PromptMenuEntry("Configs", "Choose an option", entries, uiEvents)
 	if err == nil {
 		err = bootiso.BootFromPmem(i.path, c.Label())
 	}
@@ -82,7 +82,7 @@ func (d *DownloadOption) exec(uiEvents <-chan ui.Event, network bool, cacheDir s
 
 		return "", "File name should only contain [a-zA-Z0-9_], and should end in .iso", false
 	}
-	filename, err := menu.NewInputWindow("Enter ISO name (Enter <Esc> to go back):", validIsoName, uiEvents)
+	filename, err := menu.PromptTextInput("Enter ISO name (Enter <Esc> to go back):", validIsoName, uiEvents)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (d *DownloadOption) exec(uiEvents <-chan ui.Event, network bool, cacheDir s
 
 	link, ok := bookmarks[filename]
 	if !ok {
-		if link, err = menu.NewInputWindow("Enter URL (Enter <Esc> to go back):", menu.AlwaysValid, uiEvents); err != nil {
+		if link, err = menu.PromptTextInput("Enter URL (Enter <Esc> to go back):", menu.AlwaysValid, uiEvents); err != nil {
 			return nil, err
 		}
 	}
@@ -118,7 +118,7 @@ func (d *DownloadOption) exec(uiEvents <-chan ui.Event, network bool, cacheDir s
 		if _, derr = menu.DisplayResult([]string{err.Error()}, uiEvents); derr != nil {
 			return nil, derr
 		}
-		if link, derr = menu.NewInputWindow("Enter URL (Enter <Esc> to go back):", menu.AlwaysValid, uiEvents); derr != nil {
+		if link, derr = menu.PromptTextInput("Enter URL (Enter <Esc> to go back):", menu.AlwaysValid, uiEvents); derr != nil {
 			return nil, derr
 		}
 		if link == "<Esc>" {
@@ -155,7 +155,7 @@ func (d *DirOption) exec(uiEvents <-chan ui.Event) (menu.Entry, error) {
 		}
 	}
 	entries = append(entries, &BackOption{})
-	return menu.DisplayMenu("Distros", "Choose an option", entries, uiEvents)
+	return menu.PromptMenuEntry("Distros", "Choose an option", entries, uiEvents)
 }
 
 // getCachedDirectory recognizes the usb stick that contains the cached directory from block devices,
@@ -197,7 +197,7 @@ func getMainMenu(cacheDir string) menu.Entry {
 	}
 	entries = append(entries, &DownloadOption{})
 
-	entry, err := menu.DisplayMenu("Webboot", "Choose an option:(press Ctrl-d to exit)", entries, ui.PollEvents())
+	entry, err := menu.PromptMenuEntry("Webboot", "Choose an option:(press Ctrl-d to exit)", entries, ui.PollEvents())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/menu/menu.go
+++ b/pkg/menu/menu.go
@@ -121,15 +121,10 @@ func processInput(introwords string, location int, wid int, ht int, isValid vali
 	}
 }
 
-// NewInputWindow opens a new input window with fixed width=100, hight=1.
-func NewInputWindow(introwords string, isValid validCheck, uiEvents <-chan ui.Event) (string, error) {
-	return NewCustomInputWindow(introwords, 80, 1, isValid, uiEvents)
-}
-
-// NewCustomInputWindow creates a new ui window and displays an input box.
-func NewCustomInputWindow(introwords string, wid int, ht int, isValid validCheck, uiEvents <-chan ui.Event) (string, error) {
+// PromptTextInput opens a new input window with fixed width=100, hight=1.
+func PromptTextInput(introwords string, isValid validCheck, uiEvents <-chan ui.Event) (string, error) {
 	defer ui.Clear()
-	input, _, err := processInput(introwords, 0, wid, ht, isValid, uiEvents)
+	input, _, err := processInput(introwords, 0, 80, 1, isValid, uiEvents)
 	return input, err
 }
 
@@ -291,12 +286,12 @@ func parsingMenuOption(labels []string, menu *widgets.List, input, warning *widg
 	}
 }
 
-// DisplayMenu presents all entries into a menu with numbers.
+// PromptMenuEntry presents all entries into a menu with numbers.
 // user inputs a number to choose from them.
 // customWarning allow self-defined warnings in the menu
 // for example the wifi menu want to show specific warning when user hit a specific entry,
 // because some wifi's type may not be supported.
-func DisplayMenu(menuTitle string, introwords string, entries []Entry, uiEvents <-chan ui.Event, customWarning ...string) (Entry, error) {
+func PromptMenuEntry(menuTitle string, introwords string, entries []Entry, uiEvents <-chan ui.Event, customWarning ...string) (Entry, error) {
 	defer ui.Clear()
 
 	// listData contains all choice's labels

--- a/pkg/menu/menu_test.go
+++ b/pkg/menu/menu_test.go
@@ -242,7 +242,7 @@ func TestDisplayMenu(t *testing.T) {
 			uiEvents := make(chan ui.Event)
 			go pressKey(uiEvents, tt.userInput)
 
-			chosen, err := DisplayMenu("test menu title", tt.name, tt.entries, uiEvents)
+			chosen, err := PromptMenuEntry("test menu title", tt.name, tt.entries, uiEvents)
 
 			if err != nil {
 				t.Errorf("Error: %v", err)


### PR DESCRIPTION
The menu package had two methods that would render a menu and wait for user input. The functionality worked well, but the names were a little confusing. The name changes are as follows:

- `NewInputWindow()` was renamed to `PromptTextInput()`
- `DisplayMenu()` was renamed to `PromptMenuEntry()`

The new names reflect that the functions display a menu that prompt the user for input, and then return with either a string or a `menu.Entry`