### PR TITLE
Show download bookmarks in a numbered menu

### DIFF
--- a/cmds/webboot/types.go
+++ b/cmds/webboot/types.go
@@ -7,17 +7,6 @@ import (
 	"github.com/u-root/webboot/pkg/wifi"
 )
 
-const (
-	tcURL    = "http://tinycorelinux.net/10.x/x86_64/release/TinyCorePure64-10.1.iso"
-	wbtcpURL = "https://github.com/u-root/webboot-distro/raw/master/iso/tinycore/10.x/x86_64/release/TinyCorePure64.iso"
-)
-
-// bookmark record the list of iso webboot allow user to download
-var bookmarks = map[string]string{
-	"TinyCorePure64-10.1.iso": tcURL,
-	"TinyCorePure64.iso":      wbtcpURL,
-}
-
 type Distro struct {
 	url          string
 	bootConfig   string
@@ -36,8 +25,6 @@ var supportedDistros = map[string]Distro{
 		kernelParams: "iso-scan/filename=",
 	},
 }
-
-var bookmarkList string
 
 // ISO contains information of the iso user want to boot
 type ISO struct {


### PR DESCRIPTION
Changes the menu for selecting an ISO in the `DownloadOption` to a numbered menu. Previously, the user typed the name of the desired ISO into a text input.

This PR required the following changes:

- Remove `bookmarks` and `bookmarkList` from `types.go` and `webboot.go`
- Replace the logic for selecting an ISO from a text input to a numbered menu (see `webboot.go`)
- Update test cases to use the numbered menu (see `webboot_test.go`)