### PR TITLE
Add function to infer type of cached ISO

### DIFF
--- a/cmds/webboot/types.go
+++ b/cmds/webboot/types.go
@@ -9,6 +9,7 @@ import (
 
 type Distro struct {
 	url          string
+	isoPattern   string
 	bootConfig   string
 	kernelParams string
 }
@@ -16,11 +17,13 @@ type Distro struct {
 var supportedDistros = map[string]Distro{
 	"Tinycore": Distro{
 		url:          "http://tinycorelinux.net/11.x/x86_64/release/TinyCorePure64-11.1.iso",
+		isoPattern:   ".*CorePure64-.+",
 		bootConfig:   "syslinux",
 		kernelParams: "iso=",
 	},
 	"Ubuntu": Distro{
 		url:          "https://releases.ubuntu.com/20.04.1/ubuntu-20.04.1-desktop-amd64.iso",
+		isoPattern:   "^ubuntu-.+",
 		bootConfig:   "grub",
 		kernelParams: "iso-scan/filename=",
 	},

--- a/cmds/webboot/utils.go
+++ b/cmds/webboot/utils.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 
 	"github.com/u-root/webboot/pkg/menu"
 )
@@ -76,4 +77,14 @@ func download(URL, fPath string) error {
 
 	verbose("%q is downloaded at %q\n", URL, fPath)
 	return nil
+}
+
+func inferIsoType(isoName string) string {
+	for distroName, distroInfo := range supportedDistros {
+		match, _ := regexp.MatchString(distroInfo.isoPattern, isoName)
+		if match {
+			return distroName
+		}
+	}
+	return ""
 }

--- a/cmds/webboot/webboot.go
+++ b/cmds/webboot/webboot.go
@@ -30,6 +30,11 @@ var (
 // ISO's exec downloads the iso and boot it.
 func (i *ISO) exec(uiEvents <-chan ui.Event, boot bool) error {
 	verbose("Intent to boot %s", i.path)
+
+	if distroName == "" {
+		distroName = inferIsoType(path.Base(i.path))
+	}
+
 	configs, err := bootiso.ParseConfigFromISO(i.path)
 	if err != nil {
 		return err


### PR DESCRIPTION
`supportedDistros` contains the boot parameters for the distributions we officially support. This PR adds the function `inferIsoType()` that attempts to use a cached ISO's name to match it to an entry in `supportedDistros`.

This involved adding a regex to the `Distro` struct that contains each distribution's ISO naming convention.