### PR TITLE
Add grub support to the bootiso package

### DIFF
--- a/pkg/bootiso/bootiso_test.go
+++ b/pkg/bootiso/bootiso_test.go
@@ -9,7 +9,7 @@ import (
 var isoPath string = "testdata/TinyCorePure64.iso"
 
 func TestParseConfigFromISO(t *testing.T) {
-	configOpts, err := ParseConfigFromISO(isoPath)
+	configOpts, err := ParseConfigFromISO(isoPath, "syslinux")
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Add support for grub config files in the `bootiso` package. Previously we used `syslinux.ParseLocalConfig()` to get the parse the config file for all ISOs.

Many ISOs include both a syslinux and grub config file, but as we expand our supported ISOs, we might run into some that only provide one.

In the case that no config type is specified, `bootiso.parseConfigFile()` will try both the syslinux and grub parsers and see if anything gets returned.