### PR TITLE
Implemented templates for distro kernel parameters

### DIFF
--- a/cmds/webboot/types.go
+++ b/cmds/webboot/types.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/u-root/u-root/pkg/mount/block"
 	"github.com/u-root/webboot/pkg/menu"
 	"github.com/u-root/webboot/pkg/wifi"
 )
@@ -19,14 +20,29 @@ var supportedDistros = map[string]Distro{
 		url:          "http://tinycorelinux.net/11.x/x86_64/release/TinyCorePure64-11.1.iso",
 		isoPattern:   ".*CorePure64-.+",
 		bootConfig:   "syslinux",
-		kernelParams: "iso=",
+		kernelParams: "iso=UUID={{.UUID}}{{.IsoPath}}",
 	},
 	"Ubuntu": Distro{
 		url:          "https://releases.ubuntu.com/20.04.1/ubuntu-20.04.1-desktop-amd64.iso",
 		isoPattern:   "^ubuntu-.+",
 		bootConfig:   "grub",
-		kernelParams: "iso-scan/filename=",
+		kernelParams: "iso-scan/filename={{.IsoPath}}",
 	},
+}
+
+type CacheDevice struct {
+	Name       string
+	UUID       string
+	MountPoint string
+	IsoPath    string // set after iso is selected
+}
+
+func NewCacheDevice(device *block.BlockDev, mountPoint string) CacheDevice {
+	return CacheDevice{
+		Name:       device.Name,
+		UUID:       device.FsUUID,
+		MountPoint: mountPoint,
+	}
 }
 
 // ISO contains information of the iso user want to boot


### PR DESCRIPTION
The iso scanning parameters vary between distributions. Some distros like Ubuntu just need a path like `/images/ubuntu.iso` to scan all devices for that file. Others like Tinycore work best with the UUID of the device containing the iso.

This PR adds the `CacheDevice` struct that contains parameters that might need to be passed to the new distribution. These include:

- Device name
- UUID
- Mount Point
- Path to the ISO

The kernelParams field of the `Distro` struct was modified to contain a string template. The template will be filled with the required fields from the `CacheDevice` prior to boot.

Given these changes, webboot should be capable of booting local Tinycore and Ubuntu ISOs.