### PR TITLE
Allow numbered menu to return BackOption if <Esc> is pressed

### DIFF
--- a/cmds/webboot/types.go
+++ b/cmds/webboot/types.go
@@ -132,14 +132,3 @@ func (n *Network) Label() string {
 	}
 	return "Invalid wifi network."
 }
-
-// BackOption let user back to the upper menu
-type BackOption struct {
-}
-
-var _ = menu.Entry(&BackOption{})
-
-// Label is the string this iso displays in the menu page.
-func (b *BackOption) Label() string {
-	return "Go Back"
-}

--- a/cmds/webboot/webboot_test.go
+++ b/cmds/webboot/webboot_test.go
@@ -122,7 +122,7 @@ func TestDirOption(t *testing.T) {
 
 func TestBackOption(t *testing.T) {
 	uiEvents := make(chan ui.Event)
-	input := []string{"0", "<Enter>", "1", "<Enter>"}
+	input := []string{"0", "<Enter>", "<Escape>"}
 	go pressKey(uiEvents, input)
 
 	var entry menu.Entry = &DirOption{path: "./testdata"}
@@ -134,7 +134,7 @@ func TestBackOption(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Fail to execute option (%q)'s exec(): %+v", entry.Label(), err)
 			}
-			if _, ok := entry.(*BackOption); ok {
+			if _, ok := entry.(*menu.BackOption); ok {
 				backTo := filepath.Dir(currentPath)
 				entry = &DirOption{path: backTo}
 			}

--- a/pkg/menu/menu.go
+++ b/pkg/menu/menu.go
@@ -46,6 +46,19 @@ func Close() {
 	ui.Close()
 }
 
+// BackOption is a special menu Entry that says
+// the user wants to go back to the previous menu
+type BackOption struct{}
+
+func (b *BackOption) Label() string {
+	return "Go Back"
+}
+
+func IsBackOption(entry Entry) bool {
+	_, ok := entry.(*BackOption)
+	return ok
+}
+
 // AlwaysValid is a special isValid function that check nothing
 func AlwaysValid(input string) (string, string, bool) {
 	return input, "", true
@@ -78,7 +91,7 @@ func processInput(introwords string, location int, wid int, ht int, isValid vali
 	location += 2
 	input := newParagraph("", true, location, wid, ht+2)
 	location += ht + 2
-	warning := newParagraph("", false, location, wid, 15)
+	warning := newParagraph("<Esc> to go back, <Ctrl+d> to exit", false, location, wid, 15)
 
 	ui.Render(intro)
 	ui.Render(input)
@@ -195,6 +208,8 @@ func parsingMenuOption(labels []string, menu *widgets.List, input, warning *widg
 		switch k {
 		case "<C-d>":
 			return 0, io.EOF
+		case "<Escape>":
+			return -1, nil
 		case "<Enter>":
 			choose := input.Text
 			input.Text = ""
@@ -312,7 +327,7 @@ func PromptMenuEntry(menuTitle string, introwords string, entries []Entry, uiEve
 	location += 2
 	input := newParagraph("", true, location, menuWidth, 3)
 	location += 3
-	warning := newParagraph("", false, location, menuWidth, 3)
+	warning := newParagraph("<Esc> to go back, <Ctrl+d> to exit", false, location, menuWidth, 3)
 
 	ui.Render(intro)
 	ui.Render(input)
@@ -321,6 +336,8 @@ func PromptMenuEntry(menuTitle string, introwords string, entries []Entry, uiEve
 	chooseIndex, err := parsingMenuOption(listData, menu, input, warning, uiEvents, customWarning...)
 	if err != nil {
 		return nil, fmt.Errorf("Fail to get the choose from menu: %+v", err)
+	} else if chooseIndex == -1 {
+		return &BackOption{}, nil
 	}
 
 	return entries[chooseIndex], nil


### PR DESCRIPTION
Backtracking from a numbered menu was implemented previously in the `DirOption` exec function. The implementation required manually adding a `BackOption` to the list of directory entries, and having logic to handle the selection of a `BackOption`.

This idea was extended to all numbered menus with the following changes:

- Show text at the bottom of each menu to indicate that \<Esc> returns to an earlier menu
- Move the `BackOption` struct to the menu package
- If the user types \<Esc> in a numbered menu, return a `BackOption`
- Ensure that any user-created numbered menu can properly handle a `BackOption`