### PR TITLE
Handle <Esc> press from text inputs

### DIFF
--- a/cmds/webboot/types.go
+++ b/cmds/webboot/types.go
@@ -132,3 +132,13 @@ func (n *Network) Label() string {
 	}
 	return "Invalid wifi network."
 }
+
+// BackOption is a special menu Entry that says
+// the user wants to go back to the previous menu
+type BackOption struct{}
+
+func (b *BackOption) Label() string {
+	return "Go Back"
+}
+
+var _ = menu.Entry(&BackOption{})

--- a/cmds/webboot/webboot.go
+++ b/cmds/webboot/webboot.go
@@ -93,10 +93,13 @@ func (d *DownloadOption) exec(uiEvents <-chan ui.Event, network bool, cacheDir s
 	progress.Close()
 
 	if network && !activeConnection {
-		if completed, err := setupNetwork(uiEvents); err != nil {
-			return nil, err
-		} else if !completed { // user exited the network setup
-			return &menu.BackOption{}, nil
+		if err := setupNetwork(uiEvents); err != nil {
+			switch err {
+			case menu.BackRequest:
+				return &BackOption{}, nil
+			default:
+				return nil, err
+			}
 		}
 	}
 

--- a/pkg/menu/menu.go
+++ b/pkg/menu/menu.go
@@ -162,7 +162,7 @@ func DisplayResult(message []string, uiEvents <-chan ui.Event) (string, error) {
 	p.SetRect(0, 0, wid+2, resultHeight+3)
 	p.TextStyle.Fg = ui.ColorWhite
 
-	hint := "(Press any key to continue, press <Esc> to exit.)"
+	hint := "(Press any key to continue.)"
 	msgLength := len(text)
 	currentLine := 0
 

--- a/pkg/menu/menu.go
+++ b/pkg/menu/menu.go
@@ -1,6 +1,7 @@
 package menu
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -58,6 +59,8 @@ func IsBackOption(entry Entry) bool {
 	_, ok := entry.(*BackOption)
 	return ok
 }
+
+var BackRequest = errors.New("User requested to return to a previous menu.")
 
 // AlwaysValid is a special isValid function that check nothing
 func AlwaysValid(input string) (string, string, bool) {
@@ -118,7 +121,7 @@ func processInput(introwords string, location int, wid int, ht int, isValid vali
 				ui.Render(input)
 			}
 		case "<Escape>":
-			return "<Esc>", "", nil
+			return "", "", BackRequest
 		case "<Space>":
 			input.Text += " "
 			ui.Render(input)

--- a/pkg/menu/menu_test.go
+++ b/pkg/menu/menu_test.go
@@ -94,7 +94,7 @@ func TestDisplayResult(t *testing.T) {
 			name:      "short_message",
 			msg:       []string{"short message"},
 			userInput: []string{"q"},
-			want:      "short message\n(Press any key to continue, press <Esc> to exit.)",
+			want:      "short message\n(Press any key to continue.)",
 		},
 		{
 			name: "long_message_escape",
@@ -107,7 +107,7 @@ func TestDisplayResult(t *testing.T) {
 			// which is 20 "long message" and a hint
 			want: "long message\nlong message\nlong message\nlong message\nlong message\nlong message\nlong message\nlong message\nlong message\nlong message\n" +
 				"long message\nlong message\nlong message\nlong message\nlong message\nlong message\nlong message\nlong message\nlong message\nlong message\n" +
-				"(Press any key to continue, press <Esc> to exit.)",
+				"(Press any key to continue.)",
 		},
 		{
 			name: "long message",
@@ -119,7 +119,7 @@ func TestDisplayResult(t *testing.T) {
 			// input did not contains <Escape>, so the return would be the second page's message
 			// which is 11 "long message" and a hint
 			want: "long message\nlong message\nlong message\nlong message\nlong message\nlong message\nlong message\nlong message\nlong message\nlong message\n" +
-				"long message\n(Press any key to continue, press <Esc> to exit.)",
+				"long message\n(Press any key to continue.)",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The `PromptTextInput()` function originally returned \<Esc> when the user pressed the escape key, and io.EOF when they pressed \<Ctrl+d>. Instead of checking for \<Esc>, we can return a custom error type `BackRequest` and add logic to each caller to handle the new error type.

We currently only have text input boxes in the section that collects wifi credentials, so the changes are mostly limited to `network.go`