### PR TITLE
Show percent downloaded in download progress

### DIFF
--- a/cmds/webboot/webboot_test.go
+++ b/cmds/webboot/webboot_test.go
@@ -25,7 +25,7 @@ func pressKey(ch chan ui.Event, input []string) {
 
 func TestDownload(t *testing.T) {
 	t.Run("error_link", func(t *testing.T) {
-		expected := fmt.Errorf("%q: linkopen only supports file://, https://, and http:// schemes", "errorlink")
+		expected := fmt.Errorf("%q: linkopen only supports http://, and https:// schemes", "errorlink")
 		if err := download("errorlink", "/tmp/test.iso"); err.Error() != expected.Error() {
 			t.Errorf("Error msg are wrong, want %+v but get %+v", expected, err)
 		}


### PR DESCRIPTION
The size of an incoming file is provided by `Response.ContentLength`. We can use this information to display the percentage of file downloaded. This involved the following changes:

- Update `linkOpen()` to return the expected file size. The function now supports only http and https.
- Update the `WriteCounter` object to include the fields `received` and `expected`
- Initialize `WriteCounter` with the expected file size
- Update the Sprintf expression to print the percent of file downloaded