### PR TITLE
Update backtracking return value for numbered menu

### DIFF
--- a/cmds/webboot/webboot_test.go
+++ b/cmds/webboot/webboot_test.go
@@ -134,7 +134,7 @@ func TestBackOption(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Fail to execute option (%q)'s exec(): %+v", entry.Label(), err)
 			}
-			if _, ok := entry.(*menu.BackOption); ok {
+			if _, ok := entry.(*BackOption); ok {
 				backTo := filepath.Dir(currentPath)
 				entry = &DirOption{path: backTo}
 			}


### PR DESCRIPTION
Previously, we returned a `menu.BackOption` if the user pressed \<Esc> in a numbered menu. However, in [PR 161](https://github.com/u-root/webboot/pull/161) we decided to return a new error type, `BackRequest`, if the user pressed \<Esc> from a text input menu. 

This PR modifies the numbered menu to also return a `BackRequest` error if the user presses \<Esc>.

By making this change, we can use the same error handling logic if the user presses \<Esc> from either `PromptTextInput()` or `PromptMenuEntry()`.