### PR TITLE
Infer the ISO type each time we run ISO.exec

### DIFF
--- a/cmds/webboot/utils.go
+++ b/cmds/webboot/utils.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"sort"
 
 	"github.com/u-root/webboot/pkg/menu"
 )
@@ -87,4 +88,17 @@ func inferIsoType(isoName string) string {
 		}
 	}
 	return ""
+}
+
+func supportedDistroEntries() []menu.Entry {
+	entries := []menu.Entry{}
+	for distroName, _ := range supportedDistros {
+		entries = append(entries, &Config{label: distroName})
+	}
+
+	sort.Slice(entries[:], func(i, j int) bool {
+		return entries[i].Label() < entries[j].Label()
+	})
+
+	return entries
 }


### PR DESCRIPTION
## Issue
With the addition of the back option, there is a bug with selecting ISOs. This issue can be duplicated by doing the following:

1. Select a Fedora ISO from the Cached ISO menu
2. Backtrack to the main menu
3. Select a Tinycore ISO from the Cached ISO menu

Upon selecting the 2nd ISO, the program will crash.

The issue is caused by the fact that we set the global `distroName` variable upon the first ISO selection, and then never set it again. In the example above, we would set `distroName` to _Fedora_, and when we made the second ISO selection, Webboot would assume that the Tinycore ISO was a Fedora ISO.

## Solution
Instead of setting `distroName` once, update the ISO type each time we select an ISO. We can generally infer the ISO type from the file name, but if `inferISOType()` returns an empty string, prompt the user to select the ISO's Distro Family.