### PR TITLE
Re-add custom URL option to the Download menu

### DIFF
--- a/cmds/webboot/utils.go
+++ b/cmds/webboot/utils.go
@@ -102,3 +102,12 @@ func supportedDistroEntries() []menu.Entry {
 
 	return entries
 }
+
+func validURL(url string) (string, string, bool) {
+	match, _ := regexp.MatchString("^https*://.+\\.iso$", url)
+	if match {
+		return url, "", true
+	} else {
+		return url, "Invalid URL.", false
+	}
+}

--- a/cmds/webboot/webboot.go
+++ b/cmds/webboot/webboot.go
@@ -119,6 +119,8 @@ func (d *DownloadOption) exec(uiEvents <-chan ui.Event, network bool, cacheDir s
 	}
 
 	entries := supportedDistroEntries()
+	customLabel := "Other Distro"
+	entries = append(entries, &Config{customLabel})
 	entry, err := menu.PromptMenuEntry("Linux Distros", "Choose an option:", entries, uiEvents)
 	if err != nil {
 		switch err {
@@ -129,8 +131,21 @@ func (d *DownloadOption) exec(uiEvents <-chan ui.Event, network bool, cacheDir s
 		}
 	}
 
-	distro := supportedDistros[entry.Label()]
-	link := distro.url
+	var link string
+	if entry.Label() == customLabel {
+		link, err = menu.PromptTextInput("Enter URL:", validURL, uiEvents)
+		if err != nil {
+			switch err {
+			case menu.BackRequest:
+				return &BackOption{}, nil
+			default:
+				return nil, err
+			}
+		}
+	} else {
+		distro := supportedDistros[entry.Label()]
+		link = distro.url
+	}
 	filename := path.Base(link)
 
 	// If the cachedir is not find, downloaded the iso to /tmp, else create a Downloaded dir in the cache dir.

--- a/cmds/webboot/webboot_test.go
+++ b/cmds/webboot/webboot_test.go
@@ -47,10 +47,17 @@ func TestDownload(t *testing.T) {
 }
 
 func TestDownloadOption(t *testing.T) {
-	bookmarkIso := &ISO{
+	tinycoreIso := &ISO{
 		label: "TinyCorePure64-11.1.iso",
 		path:  "testdata/Downloaded/TinyCorePure64-11.1.iso",
 	}
+
+	// Select custom distro, then type Tinycore URL manually
+	customIndex := len(supportedDistros)
+	tinycoreURL := supportedDistros["Tinycore"].url
+	customCmd := []string{strconv.Itoa(customIndex), "<Enter>"}
+	customCmd = append(customCmd, stringToKeypress(tinycoreURL)...)
+	customCmd = append(customCmd, "<Enter>")
 
 	for _, tt := range []struct {
 		name  string
@@ -60,7 +67,12 @@ func TestDownloadOption(t *testing.T) {
 		{
 			name:  "test_bookmark",
 			input: []string{strconv.Itoa(distroIndex("Tinycore")), "<Enter>"},
-			want:  bookmarkIso,
+			want:  tinycoreIso,
+		},
+		{
+			name:  "test_custom_url",
+			input: customCmd,
+			want:  tinycoreIso,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -165,4 +177,12 @@ func distroIndex(searchName string) int {
 		}
 	}
 	return -1
+}
+
+func stringToKeypress(str string) []string {
+	var keyPresses []string
+	for i := 0; i < len(str); i++ {
+		keyPresses = append(keyPresses, str[i:i+1])
+	}
+	return keyPresses
 }


### PR DESCRIPTION
When we switched the download menu from a text input to a numbered menu, we removed the ability to type a custom URL. This PR re-adds that ability by doing the following:

- Add a new Distro option called "Custom Distro" to the bookmark menu
- If the user selects the custom option, prompt them for the URL

A new test was also added that selects the "Custom Distro" option and manually types out the URL for Tinycore.