### PR TITLE
Remove BackOption type, superseded by menu.BackRequest

### DIFF
--- a/cmds/webboot/types.go
+++ b/cmds/webboot/types.go
@@ -132,13 +132,3 @@ func (n *Network) Label() string {
 	}
 	return "Invalid wifi network."
 }
-
-// BackOption is a special menu Entry that says
-// the user wants to go back to the previous menu
-type BackOption struct{}
-
-func (b *BackOption) Label() string {
-	return "Go Back"
-}
-
-var _ = menu.Entry(&BackOption{})

--- a/cmds/webboot/webboot_test.go
+++ b/cmds/webboot/webboot_test.go
@@ -112,11 +112,9 @@ func TestCancelDownload(t *testing.T) {
 	go pressKey(uiEvents, keyPresses)
 
 	downloadOption := DownloadOption{}
-	entry, err := downloadOption.exec(uiEvents, false, "./testdata")
+	_, err := downloadOption.exec(uiEvents, false, "./testdata")
 
-	if _, ok := entry.(*BackOption); !ok {
-		t.Errorf("Unknown return type %T!\n", entry)
-	} else if err != nil {
+	if err != nil && err.Error() != "Download was canceled." {
 		t.Errorf("Received error: %+v", err)
 	}
 
@@ -165,10 +163,9 @@ func TestBackOption(t *testing.T) {
 		if dirOption, ok := entry.(*DirOption); ok {
 			currentPath := dirOption.path
 			entry, err = dirOption.exec(uiEvents)
-			if err != nil {
+			if err != nil && err != menu.BackRequest {
 				t.Fatalf("Fail to execute option (%q)'s exec(): %+v", entry.Label(), err)
-			}
-			if _, ok := entry.(*BackOption); ok {
+			} else if err == menu.BackRequest {
 				backTo := filepath.Dir(currentPath)
 				entry = &DirOption{path: backTo}
 			}


### PR DESCRIPTION
Remove the `BackOption` type, since it was superseded by the `menu.BackRequest` type.

This will make error handling simpler. In the past, we used to have error handlers to check for `menu.BackRequest` and return a `BackOption` if that error type was found. That looked something like this:

```go
entry, err := PromptTextEntry(...)
if err != nil {
    switch err {
    case menu.BackRequest:
        return &BackOption, nil
    default:
        return nil, err
}
```

By restructuring the program to recognize `menu.BackRequest`, we can achieve the same effect with the following:

```go
entry, err := PromptTextEntry(...)
if err != nil {
    return err
}
```