### PR TITLE
Added checksum validation function to the bootiso package

### DIFF
--- a/pkg/bootiso/bootiso_test.go
+++ b/pkg/bootiso/bootiso_test.go
@@ -28,6 +28,43 @@ func TestParseConfigFromISO(t *testing.T) {
 	}
 }
 
+func TestChecksum(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		checksumPath string
+		checksumType string
+		valid        bool
+	}{
+		{
+			name:         "valid_md5",
+			checksumPath: "testdata/TinyCorePure64.md5.txt",
+			checksumType: "md5",
+			valid:        true,
+		},
+		{
+			name:         "valid_sha256",
+			checksumPath: "testdata/TinyCorePure64.sha256.txt",
+			checksumType: "sha256",
+			valid:        true,
+		},
+		{
+			name:         "invalid_md5",
+			checksumPath: "testdata/TinyCorePure64.sha256.txt",
+			checksumType: "md5",
+			valid:        false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			valid, err := VerifyChecksum(isoPath, test.checksumPath, test.checksumType)
+			if err != nil {
+				t.Error(err)
+			} else if valid != test.valid {
+				t.Errorf("Checksum validation was expected to result in %t.\n", test.valid)
+			}
+		})
+	}
+}
+
 func TestMain(m *testing.M) {
 	if _, err := os.Stat(isoPath); err != nil {
 		log.Fatal("ISO file was not found in the testdata directory.")

--- a/pkg/bootiso/testdata/TinyCorePure64.md5.txt
+++ b/pkg/bootiso/testdata/TinyCorePure64.md5.txt
@@ -1,0 +1,1 @@
+10a79ba7558598574cd396e7b1b057b7  TinyCorePure64.iso

--- a/pkg/bootiso/testdata/TinyCorePure64.sha256.txt
+++ b/pkg/bootiso/testdata/TinyCorePure64.sha256.txt
@@ -1,0 +1,1 @@
+01ce6b5f4e4f7e98eddc343fc14f1436fb1b0452e6b9f7e07461b6a089a909c1  TinyCorePure64.iso


### PR DESCRIPTION
Added a function to validate the checksum, given an ISO and its checksum file.

The checksum file provided with an ISO will look something like this:

```
2f6ae466ec9b7c6255e997b82f162ae88bfe640a8df16d3e2f495b6281120af9 *linuxmint-20-cinnamon-64bit.iso
42fd764b3a3544a36d820f4164bb64aa5a6d982073e6d1afdea4853d3858fc98 *linuxmint-20-mate-64bit.iso
761fb276da9746a068f4c8aa42e8d4981f352db92babe0ef8a08713eeb38246f *linuxmint-20-xfce-64bit.iso
```

We can parse out the checksum by finding the line that contains the ISO's filename. After calculating the ISO checksum ourselves, we can compare the calculated and parsed checksums.

A few tests are included to verify that the checksum function works as expected.