### PR TITLE
Check for file before attempting to download

### DIFF
--- a/cmds/webboot/utils.go
+++ b/cmds/webboot/utils.go
@@ -135,3 +135,20 @@ func validURL(url string) (string, string, bool) {
 		return url, "Invalid URL.", false
 	}
 }
+
+// TODO: Verify that this logic is valid
+func fileExists(filepath string) bool {
+	info, err := os.Stat(filepath)
+	return err == nil && info.Mode().IsRegular()
+}
+
+func checksumInfo(isoPath string) (string, string) {
+	checksumTypes := []string{"md5", "sha256"}
+	for _, checksumType := range checksumTypes {
+		checksumFile := isoPath + "." + checksumType
+		if fileExists(checksumFile) {
+			return checksumFile, checksumType
+		}
+	}
+	return "", ""
+}


### PR DESCRIPTION
We are not currently checking if an ISO already exists before we download it. This PR adds the logic to check for this.

Suppose the user requests to download an ISO, but we already have a copy. There are 3 cases to consider:

- Checksum file was not found
- Checksum file exists, but does not match ISO
- Checksum matches the ISO

Based on the case, display a message to the user and ask if they would like to continue with the download.

- If yes, erase the current ISO and its checksum file (if exists) and redownload
- If no, return to the main menu