### PR TITLE
Add support for CentOS 7 and Kali

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,11 @@ ISOs must have the following to be compatible with `webboot`.
 Additional operating systems can be added by appending an entry to the `supportedDistros` map in `/cmds/webboot/types.go`.
 
 ### Currently Supported
-| Name | Required Kernel Parameters |
-| ----- | ------ |
+| Name | Required Kernel Parameters | Notes |
+| ----- | ------ | ----- |
+| CentOS | `iso-scan/filename=PATH_TO_ISO` | CentOS 7 supports live mode. CentOS 8 will boot to the graphical installer.
 | Fedora | `iso-scan/filename=PATH_TO_ISO` |
+| Kali | `findiso=PATH_TO_ISO` |
 | Linux Mint | `iso-scan/filename=PATH_TO_ISO` |
 | Tinycore | `iso=UUID/PATH_TO_ISO` |
 | Ubuntu | `iso-scan/filename=PATH_TO_ISO` |

--- a/cmds/webboot/types.go
+++ b/cmds/webboot/types.go
@@ -16,9 +16,15 @@ type Distro struct {
 }
 
 var supportedDistros = map[string]Distro{
+	"CentOS 7": Distro{
+		url:          "https://sjc.edge.kernel.org/centos/7/isos/x86_64/CentOS-7-x86_64-LiveGNOME-2003.iso",
+		isoPattern:   "^CentOS-7.+",
+		bootConfig:   "grub",
+		kernelParams: "iso-scan/filename={{.IsoPath}}",
+	},
 	"CentOS 8": Distro{
 		url:          "https://sjc.edge.kernel.org/centos/8.2.2004/isos/x86_64/CentOS-8.2.2004-x86_64-minimal.iso",
-		isoPattern:   "^CentOS-.+",
+		isoPattern:   "^CentOS-8.+",
 		bootConfig:   "grub",
 		kernelParams: "iso-scan/filename={{.IsoPath}}",
 	},
@@ -27,6 +33,12 @@ var supportedDistros = map[string]Distro{
 		isoPattern:   "^Fedora-.+",
 		bootConfig:   "grub",
 		kernelParams: "iso-scan/filename={{.IsoPath}}",
+	},
+	"Kali": Distro{
+		url:          "https://cdimage.kali.org/kali-2020.3/kali-linux-2020.3-live-amd64.iso",
+		isoPattern:   "^kali-linux-.+",
+		bootConfig:   "grub",
+		kernelParams: "findiso={{.IsoPath}}",
 	},
 	"Linux Mint": Distro{
 		url:          "http://mirrors.kernel.org/linuxmint/stable/20/linuxmint-20-cinnamon-64bit.iso",


### PR DESCRIPTION
Add entries for CentOS 7 and Kali Linux to the `supportedDistros` table.

Also update the _Supported Distros_ section of the README to reflect this change.