### PR TITLE
Avoid parsing config file twice by storing boot.OSImage

### DIFF
--- a/cmds/webboot/types.go
+++ b/cmds/webboot/types.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/u-root/u-root/pkg/boot"
 	"github.com/u-root/u-root/pkg/mount/block"
 	"github.com/u-root/webboot/pkg/menu"
 	"github.com/u-root/webboot/pkg/wifi"
@@ -149,4 +150,12 @@ func (n *Network) Label() string {
 		return fmt.Sprintf("%s: Not a supported protocol\n", n.info.Essid)
 	}
 	return "Invalid wifi network."
+}
+
+type BootConfig struct {
+	image boot.OSImage
+}
+
+func (b *BootConfig) Label() string {
+	return b.image.Label()
 }

--- a/cmds/webboot/webboot.go
+++ b/cmds/webboot/webboot.go
@@ -63,12 +63,17 @@ func (i *ISO) exec(uiEvents <-chan ui.Event, boot bool) error {
 
 	entries := []menu.Entry{}
 	for _, config := range configs {
-		entries = append(entries, &Config{label: config.Label()})
+		entries = append(entries, &BootConfig{config})
 	}
 
-	c, err := menu.PromptMenuEntry("Configs", "Choose an option", entries, uiEvents)
+	entry, err := menu.PromptMenuEntry("Configs", "Choose an option", entries, uiEvents)
 	if err != nil {
 		return err
+	}
+
+	config, ok := entry.(*BootConfig)
+	if !ok {
+		return fmt.Errorf("Could not convert selection to a boot image.")
 	}
 
 	if err == nil {
@@ -83,7 +88,7 @@ func (i *ISO) exec(uiEvents <-chan ui.Event, boot bool) error {
 			return err
 		}
 
-		err = bootiso.BootCachedISO(i.path, c.Label(), distro.bootConfig, kernelParams.String())
+		err = bootiso.BootCachedISO(config.image, kernelParams.String())
 	}
 
 	// If kexec succeeds, we should not arrive here

--- a/pkg/bootiso/bootiso.go
+++ b/pkg/bootiso/bootiso.go
@@ -115,17 +115,7 @@ func BootFromPmem(isoPath string, configLabel string, configType string) error {
 	return nil
 }
 
-func BootCachedISO(isoPath string, configLabel string, configType string, kernelParams string) error {
-	configOpts, err := ParseConfigFromISO(isoPath, configType)
-	if err != nil {
-		return fmt.Errorf("Error retrieving config options: %v", err)
-	}
-
-	osImage := findConfigOptionByLabel(configOpts, configLabel)
-	if osImage == nil {
-		return fmt.Errorf("Config option with the requested label does not exist")
-	}
-
+func BootCachedISO(osImage boot.OSImage, kernelParams string) error {
 	// Need to convert from boot.OSImage to boot.LinuxImage to edit the Cmdline
 	linuxImage, ok := osImage.(*boot.LinuxImage)
 	if !ok {


### PR DESCRIPTION
We currently parse the config file twice during the boot process.

1. To retrieve the boot configurations to display to the user
2. Before the actual boot, to retrieve the `boot.OSImage` corresponding to the user's choice

However, the initial call to `bootiso.ParseConfigFromISO()` returns a list of `boot.OSImage` objects that we can pass directly to the second step. This PR stores the returned `boot.OSImage` objects in a new `menu.Entry` type, which can then be passed directly to `bootiso.BootCachedISO()`.