### PR TITLE
Added LoadCustomConfigs() to the bootiso package

### DIFF
--- a/pkg/bootiso/bootiso_test.go
+++ b/pkg/bootiso/bootiso_test.go
@@ -65,6 +65,51 @@ func TestChecksum(t *testing.T) {
 	}
 }
 
+func TestCustomConfigs(t *testing.T) {
+	var configs []Config
+	for i := 0; i < 5; i++ {
+		configs = append(configs, Config{
+			Label:      "Custom Config " + string(i),
+			KernelPath: "/boot/vmlinuz64",
+			InitrdPath: "/boot/corepure64.gz",
+			Cmdline:    "loglevel=3 vga=791",
+		})
+	}
+
+	for _, test := range []struct {
+		name    string
+		configs []Config
+	}{
+		{
+			name:    "empty_list",
+			configs: []Config{},
+		},
+		{
+			name:    "single_config",
+			configs: configs[:1],
+		},
+		{
+			name:    "multiple_configs",
+			configs: configs,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			images, err := LoadCustomConfigs(isoPath, test.configs)
+			if err != nil {
+				t.Error(err)
+			} else if len(test.configs) != len(images) {
+				t.Errorf("Test contained %d configs, but only received %d images.", len(test.configs), len(images))
+			}
+
+			for index, image := range images {
+				if test.configs[index].Label != image.Label() {
+					t.Errorf("Expected label %q but received %q.", test.configs[index].Label, image.Label())
+				}
+			}
+		})
+	}
+}
+
 func TestMain(m *testing.M) {
 	if _, err := os.Stat(isoPath); err != nil {
 		log.Fatal("ISO file was not found in the testdata directory.")


### PR DESCRIPTION
We currently do not support ISOs with difficult-to-parse config files. One way around this is to manually specify the following information, which is usually parsed from the config file:

- Path to kernel
- Path to initrd
- Kernel parameters

This PR adds the `Config` type to the bootiso package, where we can specify these details.

In addition, the `LoadCustomConfigs()` function was added. This essentially does the job of `ParseConfigFromISO()`, except the boot configurations are specified in a list of `Config` objects rather than a config file.

Finally, a new test was added that runs `LoadCustomConfigs()` on our TinyCore ISO and a list of `Config` objects.