### PR TITLE
Use custom boot configs in the main webboot program

### DIFF
--- a/cmds/webboot/types.go
+++ b/cmds/webboot/types.go
@@ -5,18 +5,33 @@ import (
 
 	"github.com/u-root/u-root/pkg/boot"
 	"github.com/u-root/u-root/pkg/mount/block"
+	"github.com/u-root/webboot/pkg/bootiso"
 	"github.com/u-root/webboot/pkg/menu"
 	"github.com/u-root/webboot/pkg/wifi"
 )
 
 type Distro struct {
-	url          string
-	isoPattern   string
-	bootConfig   string
-	kernelParams string
+	url           string
+	isoPattern    string
+	bootConfig    string
+	kernelParams  string
+	customConfigs []bootiso.Config
 }
 
 var supportedDistros = map[string]Distro{
+	"Arch": Distro{
+		url:          "https://mirrors.edge.kernel.org/archlinux/iso/2020.09.01/archlinux-2020.09.01-x86_64.iso",
+		isoPattern:   "^archlinux-.+",
+		kernelParams: "img_dev=/dev/disk/by-uuid/{{.UUID}} img_loop={{.IsoPath}}",
+		customConfigs: []bootiso.Config{
+			bootiso.Config{
+				Label:      "Default Config",
+				KernelPath: "/arch/boot/x86_64/vmlinuz-linux",
+				InitrdPath: "/arch/boot/x86_64/archiso.img",
+				Cmdline:    "",
+			},
+		},
+	},
 	"CentOS 7": Distro{
 		url:          "https://sjc.edge.kernel.org/centos/7/isos/x86_64/CentOS-7-x86_64-LiveGNOME-2003.iso",
 		isoPattern:   "^CentOS-7.+",
@@ -46,6 +61,19 @@ var supportedDistros = map[string]Distro{
 		isoPattern:   "^linuxmint-.+",
 		bootConfig:   "grub",
 		kernelParams: "iso-scan/filename={{.IsoPath}}",
+	},
+	"Manjaro": Distro{
+		url:          "https://mirrors.gigenet.com/OSDN//storage/g/m/ma/manjaro/xfce/20.1/minimal/manjaro-xfce-20.1-minimal-200911-linux58.iso",
+		isoPattern:   "^manjaro-.+",
+		kernelParams: "img_dev=/dev/disk/by-uuid/{{.UUID}} img_loop={{.IsoPath}}",
+		customConfigs: []bootiso.Config{
+			bootiso.Config{
+				Label:      "Default Config",
+				KernelPath: "/boot/vmlinuz-x86_64",
+				InitrdPath: "/boot/initramfs-x86_64.img",
+				Cmdline:    "driver=free tz=utc lang=en_US keytable=en",
+			},
+		},
 	},
 	"Tinycore": Distro{
 		url:          "http://tinycorelinux.net/11.x/x86_64/release/TinyCorePure64-11.1.iso",

--- a/cmds/webboot/webboot.go
+++ b/cmds/webboot/webboot.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	ui "github.com/gizak/termui/v3"
+	Boot "github.com/u-root/u-root/pkg/boot"
 	"github.com/u-root/u-root/pkg/mount"
 	"github.com/u-root/u-root/pkg/mount/block"
 	"github.com/u-root/webboot/pkg/bootiso"
@@ -49,10 +50,26 @@ func (i *ISO) exec(uiEvents <-chan ui.Event, boot bool) error {
 		distro = supportedDistros[entry.Label()]
 	}
 
-	configs, err := bootiso.ParseConfigFromISO(i.path, distro.bootConfig)
-	if err != nil {
-		return err
-	} else if len(configs) == 0 {
+	var configs []Boot.OSImage
+	if distro.bootConfig != "" {
+		parsedConfigs, err := bootiso.ParseConfigFromISO(i.path, distro.bootConfig)
+		if err != nil {
+			return err
+		}
+
+		configs = append(configs, parsedConfigs...)
+	}
+
+	if len(distro.customConfigs) != 0 {
+		customConfigs, err := bootiso.LoadCustomConfigs(i.path, distro.customConfigs)
+		if err != nil {
+			return err
+		}
+
+		configs = append(configs, customConfigs...)
+	}
+
+	if len(configs) == 0 {
 		return fmt.Errorf("No valid configs were found.")
 	}
 


### PR DESCRIPTION
With the addition of the `Config` type in [PR 182](https://github.com/u-root/webboot/pull/182), we can now specify boot configurations in the `supportedDistros` table. This allows us to get around the issue of ISOs with config files that are difficult for our parser to handle.

This PR adds the `customConfigs` field to the `Distro` type. Using this new field, we also add support for Arch Linux and Manjaro, which were previously unsupported because of their complex config files.