### PR TITLE
Allow selecting off-screen menu options

### DIFF
--- a/pkg/menu/menu.go
+++ b/pkg/menu/menu.go
@@ -256,10 +256,9 @@ func parsingMenuOption(labels []string, menu *widgets.List, input, warning *widg
 			input.Text = ""
 			ui.Render(input)
 			c, err := strconv.Atoi(choose)
-			// input is vilid when:
-			// 1.input is a number;
-			// 2.the number does not exceed the index in the current page.
-			if err == nil && c >= first && c < last {
+			// Input is valid if the selected index
+			// is between 0 <= input < len(labels)
+			if err == nil && c >= 0 && c < len(labels) {
 				// if there is not specific warning for this entry, return it
 				// elsewise show the warning and continue
 				if len(customWarning) > c && customWarning[c] != "" {

--- a/pkg/menu/menu_test.go
+++ b/pkg/menu/menu_test.go
@@ -326,14 +326,14 @@ func TestDisplayMenu(t *testing.T) {
 			name:    "<Left>_<Right>_exceed_the_bound_then_right_input",
 			entries: []Entry{entry1, entry2, entry3, entry4, entry5, entry6, entry7, entry8, entry9, entry10, entry11, entry12},
 			// hit <Left> -> <Right> current page is : 10~11 because the first <Left> should do nothing
-			userInput: []string{"<Left>", "<Right>", "8", "<Enter>", "1", "0", "<Enter>"},
+			userInput: []string{"<Left>", "<Right>", "-", "1", "<Enter>", "1", "0", "<Enter>"},
 			want:      entry11,
 		},
 		{
 			name:    "<Down>_<Down>_<Up>_exceed_the_bound_then_right_input",
 			entries: []Entry{entry1, entry2, entry3, entry4, entry5, entry6, entry7, entry8, entry9, entry10, entry11, entry12},
 			// hit <Down> -> <Down> -> <Up> current page is : 1~10
-			userInput: []string{"<Down>", "<Down>", "<Up>", "0", "<Enter>", "1", "<Enter>"},
+			userInput: []string{"<Down>", "<Down>", "<Up>", "2", "1", "<Enter>", "1", "<Enter>"},
 			want:      entry2,
 		},
 		{


### PR DESCRIPTION
Currently, a user can only selection an option from a numbered menu if it is displayed on screen. This might be inconvenient if the user would like to select the option from the bottom of the list and already know the index. Instead of just entering the index when the screen appears, they need to scroll to the bottom of the list before they can make the selection.

This PR changes the bounds for a valid selection from the numbered menu, and updates the unit tests for the numbered menu.