### PR TITLE
Tweak pmem in syslinux.cfg.example to start at 512M

### DIFF
--- a/syslinux.cfg.example
+++ b/syslinux.cfg.example
@@ -6,6 +6,6 @@ TIMEOUT 1
 LABEL webboot
   KERNEL /boot/webboot
   INITRD /boot/webboot.cpio.gz
-  APPEND earlyprintk=tty0 earlyprintk=ttyS0,115200,keep console=ttyS0 console=tty0 memmap=1G!1G vga=ask
+  APPEND earlyprintk=tty0 earlyprintk=ttyS0,115200,keep console=ttyS0 console=tty0 memmap=1G!512M vga=ask
 
 


### PR DESCRIPTION
Some chromebooks don't have a full memory region at 1G for 1G.
Pmem is so fragile that it locks up the kernel in that case.

Until we can stop using pmem, at least make it lock things up
less.