### PR TITLE
Change VerifyChecksum to take checksum

### DIFF
--- a/pkg/bootiso/bootiso.go
+++ b/pkg/bootiso/bootiso.go
@@ -1,7 +1,6 @@
 package bootiso
 
 import (
-	"bufio"
 	"context"
 	"crypto/md5"
 	"crypto/sha256"
@@ -359,21 +358,15 @@ func BootCachedISO(osImage boot.OSImage, kernelParams string) error {
 	return nil
 }
 
-// VerifyChecksum takes a path to the ISO and its checksum file
+// VerifyChecksum takes a path to the ISO and its checksum
 // and compares the calculated checksum on the ISO
-// against the value parsed from the checksum file
-func VerifyChecksum(isoPath, checksumPath, checksumType string) (bool, error) {
+// against the checksum
+func VerifyChecksum(isoPath, checksum, checksumType string) (bool, error) {
 	iso, err := os.Open(isoPath)
 	if err != nil {
 		return false, err
 	}
 	defer iso.Close()
-
-	checksumFile, err := os.Open(checksumPath)
-	if err != nil {
-		return false, err
-	}
-	defer checksumFile.Close()
 
 	var hash hash.Hash
 	switch checksumType {
@@ -390,22 +383,8 @@ func VerifyChecksum(isoPath, checksumPath, checksumType string) (bool, error) {
 	}
 	calcChecksum := hex.EncodeToString(hash.Sum(nil))
 
-	var parsedChecksum string
-	isoName := path.Base(isoPath)
-	scanner := bufio.NewScanner(checksumFile)
 
-	// Checksum file should contain a line with
-	// the checksum and the ISO file name
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.Contains(line, isoName) {
-			splitLine := strings.Split(line, " ")
-			parsedChecksum = splitLine[0]
-			break
-		}
-	}
-
-	return calcChecksum == parsedChecksum, nil
+	return calcChecksum == checksum, nil
 }
 
 func findConfigOptionByLabel(configOptions []boot.OSImage, configLabel string) boot.OSImage {

--- a/pkg/bootiso/bootiso_test.go
+++ b/pkg/bootiso/bootiso_test.go
@@ -32,31 +32,31 @@ func TestParseConfigFromISO(t *testing.T) {
 func TestChecksum(t *testing.T) {
 	for _, test := range []struct {
 		name         string
-		checksumPath string
+		checksum     string
 		checksumType string
 		valid        bool
 	}{
 		{
 			name:         "valid_md5",
-			checksumPath: "testdata/TinyCorePure64.md5.txt",
+			checksum:     "10a79ba7558598574cd396e7b1b057b7",
 			checksumType: "md5",
 			valid:        true,
 		},
 		{
 			name:         "valid_sha256",
-			checksumPath: "testdata/TinyCorePure64.sha256.txt",
+			checksum:     "01ce6b5f4e4f7e98eddc343fc14f1436fb1b0452e6b9f7e07461b6a089a909c1", 
 			checksumType: "sha256",
 			valid:        true,
 		},
 		{
 			name:         "invalid_md5",
-			checksumPath: "testdata/TinyCorePure64.sha256.txt",
+			checksum: "99979ba7558598574cd396e7b1b057b7",
 			checksumType: "md5",
 			valid:        false,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			valid, err := VerifyChecksum(isoPath, test.checksumPath, test.checksumType)
+			valid, err := VerifyChecksum(isoPath, test.checksum, test.checksumType)
 			if err != nil {
 				t.Error(err)
 			} else if valid != test.valid {


### PR DESCRIPTION
VerifyChecksum now takes a checksum instead of a path to a checksum
file. bootiso_test.go is also updated to reflect this change.

Signed-off-by: Kelly Sun <sunkelly888@gmail.com>