### PR TITLE
Verify checksum in exec

### DIFF
--- a/cmds/webboot/testdata/dirlevel1/fakeDistro.iso
+++ b/cmds/webboot/testdata/dirlevel1/fakeDistro.iso
@@ -1,0 +1,1 @@
+This is a fake ISO.

--- a/cmds/webboot/types.go
+++ b/cmds/webboot/types.go
@@ -190,7 +190,7 @@ func NewCacheDevice(device *block.BlockDev, mountPoint string) CacheDevice {
 	}
 }
 
-// ISO contains information of the iso user want to boot
+// ISO contains information of the iso user wants to boot.
 type ISO struct {
 	label    string
 	path     string
@@ -204,7 +204,7 @@ func (i *ISO) Label() string {
 	return i.label
 }
 
-// Config represents one kind of configure of booting an iso
+// Config represents one kind of configure of booting an iso.
 type Config struct {
 	label string
 }
@@ -216,7 +216,7 @@ func (c *Config) Label() string {
 	return c.label
 }
 
-// DownloadOption let user download an iso then boot it
+// DownloadOption lets the user download an iso then boot it.
 type DownloadOption struct {
 }
 
@@ -227,8 +227,8 @@ func (d *DownloadOption) Label() string {
 	return "Download an ISO"
 }
 
-// DirOption represents a directory under cache directory
-// it displays it's sub-directory or iso files
+// DirOption represents a directory under cache directory.
+// It displays its sub-directory or iso files.
 type DirOption struct {
 	label string
 	path  string

--- a/pkg/bootiso/bootiso.go
+++ b/pkg/bootiso/bootiso.go
@@ -3,6 +3,7 @@ package bootiso
 import (
 	"context"
 	"crypto/md5"
+	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -359,12 +360,13 @@ func BootCachedISO(osImage boot.OSImage, kernelParams string) error {
 }
 
 // VerifyChecksum takes a path to the ISO and its checksum
-// and compares the calculated checksum on the ISO
-// against the checksum
-func VerifyChecksum(isoPath, checksum, checksumType string) (bool, error) {
+// and compares the calculated checksum on the ISO against the checksum.
+// It returns true if the checksum was correct, false if the checksum
+// was incorrect, the calculated checksum, and an error.
+func VerifyChecksum(isoPath, checksum, checksumType string) (bool, string, error) {
 	iso, err := os.Open(isoPath)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 	defer iso.Close()
 
@@ -372,18 +374,20 @@ func VerifyChecksum(isoPath, checksum, checksumType string) (bool, error) {
 	switch checksumType {
 	case "md5":
 		hash = md5.New()
+	case "sha1":
+		hash = sha1.New()
 	case "sha256":
 		hash = sha256.New()
 	default:
-		return false, fmt.Errorf("Unknown checksum type.")
+		return false, "", fmt.Errorf("Unknown checksum type.")
 	}
 
 	if _, err := io.Copy(hash, iso); err != nil {
-		return false, err
+		return false, "", err
 	}
 	calcChecksum := hex.EncodeToString(hash.Sum(nil))
 
-	return calcChecksum == checksum, nil
+	return calcChecksum == checksum, calcChecksum, nil
 }
 
 func findConfigOptionByLabel(configOptions []boot.OSImage, configLabel string) boot.OSImage {

--- a/pkg/bootiso/bootiso_test.go
+++ b/pkg/bootiso/bootiso_test.go
@@ -56,11 +56,13 @@ func TestChecksum(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			valid, err := VerifyChecksum(isoPath, test.checksum, test.checksumType)
+			valid, calcChecksum, err := VerifyChecksum(isoPath, test.checksum, test.checksumType)
 			if err != nil {
 				t.Error(err)
 			} else if valid != test.valid {
 				t.Errorf("Checksum validation was expected to result in %t.\n", test.valid)
+			} else if len(calcChecksum) == 0 {
+				t.Errorf("Should have returned a checksum")
 			}
 		})
 	}


### PR DESCRIPTION
After an ISO has finished downloading and if the distro selected has a
checksum available, VerifyChecksum is called.

If the checksum for the ISO does not match the correct checksum for that
distro, the user will be asked whether or not they want to proceed
anyway. If not, the user will be taken back to the list of distro
options to pick a new one to download.

Signed-off-by: Kelly Sun <sunkelly888@gmail.com>