### PR TITLE
Print something in CI when gofmt fails

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -2,7 +2,13 @@
 set -e
 
 # Check that the code has been formatted correctly.
-test -z "$(gofmt -s -l *.go pkg cmds)"
+GOFMT_DIFF=$(gofmt -s -d *.go pkg cmds)
+if [[ -n "${GOFMT_DIFF}" ]]; then
+	echo 'Error: Go source code is not formatted:'
+	printf '%s\n' "${GOFMT_DIFF}"
+	echo 'Run `gofmt -s -w *.go pkg cmds'
+	exit 1
+fi
 
 go build .
 go run webboot.go


### PR DESCRIPTION
Currently, the CI fails with "Error: Process completed with exit code
1." This change adds more useful info.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>