### PR TITLE
Throw away values from menus channel

### DIFF
--- a/cmds/webboot/webboot.go
+++ b/cmds/webboot/webboot.go
@@ -387,6 +387,12 @@ func main() {
 	}
 
 	menus := make(chan string)
+	// Continuously throw away values from menus channel so that the channel doesn't block.
+	go func() {
+		for {
+			<-menus
+		}
+	}()
 	entry := getMainMenu(cacheDir, menus)
 
 	// Buffer the log output, else it might overlap with the menu


### PR DESCRIPTION
Add a go func that throws away values from the menus channel so that the
channel doesn't block. We can throw these values away because they are
only important for the tests.

Signed-off-by: Kelly Sun <sunkelly888@gmail.com>