### PR TITLE
Use default JSON file if download fails

### DIFF
--- a/webboot.go
+++ b/webboot.go
@@ -81,6 +81,7 @@ func main() {
 			"-files", extraBinMust("wpa_passphrase"),
 			"-files", filepath.Join(currentDir, "cmds", "webboot", "webboot")+":bbin/webboot",
 			"-files", extraBinMust("strace"),
+			"-files", "cmds/webboot/distros.json:/distros.json",
 		)
 	}
 	if *bzImage != "" {


### PR DESCRIPTION
If the JSON file containing the distro data is not able to be downloaded,
a screen will pop up notifying the user that the download was not
successful. It will also prompt them to press "0", which will make the
program continue with the default json file.

Signed-off-by: Kelly Sun <sunkelly888@gmail.com>