### PR TITLE
Allow user input for JSON URL

### DIFF
--- a/cmds/webboot/utils.go
+++ b/cmds/webboot/utils.go
@@ -130,11 +130,19 @@ func supportedDistroEntries() []menu.Entry {
 	return entries
 }
 
-func validURL(url string) (string, string, bool) {
-	match, _ := regexp.MatchString("^https*://.+\\.iso$", url)
+func validURL(url string, ext string) (string, string, bool) {
+	match, _ := regexp.MatchString(fmt.Sprintf("^https*://.+\\.%s$", ext), url)
 	if match {
 		return url, "", true
 	} else {
 		return url, "Invalid URL.", false
 	}
+}
+
+func validIso(url string) (string, string, bool) {
+	return validURL(url, "iso")
+}
+
+func validJson(url string) (string, string, bool) {
+	return validURL(url, "json")
 }


### PR DESCRIPTION
Add a new menu that allows users to choose the list of distros that they
want. The options are downloaded, local, or a new option that allows users
to type in the url of the json file.

Signed-off-by: Kelly Sun <sunkelly888@gmail.com>