### PR TITLE
Download ISOs to USB instead of RAM

### DIFF
--- a/cmds/webboot/webboot.go
+++ b/cmds/webboot/webboot.go
@@ -154,17 +154,20 @@ func (d *DownloadOption) exec(uiEvents <-chan ui.Event, menus chan<- string, net
 
 	// If the cachedir is not find, downloaded the iso to /tmp, else create a Downloaded dir in the cache dir.
 	var fpath string
+	var downloadDir string
+
 	if cacheDir == "" {
-		fpath = filepath.Join(os.TempDir(), filename)
+		downloadDir = os.TempDir()
+		fpath = filepath.Join(downloadDir, filename)
 	} else {
-		downloadDir := filepath.Join(cacheDir, "Downloaded")
+		downloadDir = filepath.Join(cacheDir, "Downloaded")
 		if err = os.MkdirAll(downloadDir, os.ModePerm); err != nil {
 			return nil, fmt.Errorf("Fail to create the downloaded dir :%v", err)
 		}
 		fpath = filepath.Join(downloadDir, filename)
 	}
 
-	if err = download(link, fpath, uiEvents); err != nil {
+	if err = download(link, fpath, downloadDir, uiEvents); err != nil {
 		if err == context.Canceled {
 			return nil, fmt.Errorf("Download was canceled.")
 		} else {
@@ -252,10 +255,13 @@ func distroData(uiEvents <-chan ui.Event, menus chan<- string, cacheDir string) 
 	}
 
 	if needDownload {
+		var downloadDir string
+
 		if cacheDir == "" {
-			jsonPath = filepath.Join(os.TempDir(), "distros.json")
+			downloadDir = os.TempDir()
+			jsonPath = filepath.Join(downloadDir, "distros.json")
 		} else {
-			downloadDir := filepath.Join(cacheDir, "Downloaded")
+			downloadDir = filepath.Join(cacheDir, "Downloaded")
 			if err := os.MkdirAll(downloadDir, os.ModePerm); err != nil {
 				return nil, fmt.Errorf("Fail to create the downloaded dir: %v", err)
 			}
@@ -263,7 +269,7 @@ func distroData(uiEvents <-chan ui.Event, menus chan<- string, cacheDir string) 
 		}
 
 		// Download the json file.
-		if err := download(jsonLink, jsonPath, uiEvents); err != nil {
+		if err := download(jsonLink, jsonPath, downloadDir, uiEvents); err != nil {
 			if err == context.Canceled {
 				return nil, fmt.Errorf("JSON file download was canceled.")
 			} else {

--- a/cmds/webboot/webboot_test.go
+++ b/cmds/webboot/webboot_test.go
@@ -174,7 +174,7 @@ func TestDownload(t *testing.T) {
 	t.Run("error_link", func(t *testing.T) {
 		errorLink := "errorlink"
 		expected := fmt.Errorf("Get %q: unsupported protocol scheme \"\"", errorLink)
-		if err := download(errorLink, "/tmp/test.iso", uiEvents); err.Error() != expected.Error() {
+		if err := download(errorLink, "/tmp/test.iso", "/testdata", uiEvents); err.Error() != expected.Error() {
 			t.Errorf("Expected %+v, received %+v", expected, err)
 		}
 	})
@@ -189,7 +189,7 @@ func TestDownload(t *testing.T) {
 
 		// Download the ISO from the fake server.
 		u := supportedDistros["FakeTinycore"].Mirrors[0].Url
-		if err := download(u, fPath, uiEvents); err != nil {
+		if err := download(u, fPath, tmpDir, uiEvents); err != nil {
 			t.Fatalf("Fail to download: %+v", err)
 		}
 		s, err := os.Stat(fPath)

--- a/webboot.go
+++ b/webboot.go
@@ -81,7 +81,7 @@ func main() {
 			"-files", extraBinMust("wpa_passphrase"),
 			"-files", filepath.Join(currentDir, "cmds", "webboot", "webboot")+":bbin/webboot",
 			"-files", extraBinMust("strace"),
-			"-files", "cmds/webboot/distros.json:/distros.json",
+			"-files", "cmds/webboot/distros.json:distros.json",
 		)
 	}
 	if *bzImage != "" {


### PR DESCRIPTION
Previously, ISOs were downloaded to RAM then copied to the USB,
but this doesn't work for large ISOs because RAM runs out of space. 
Now, ISOs are downloaded directly to the USB.

Signed-off-by: Kelly Sun <sunkelly888@gmail.com>