### PR TITLE
Add files for cli

### DIFF
--- a/cmds/cli/types.go
+++ b/cmds/cli/types.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"github.com/u-root/u-root/pkg/boot"
+	"github.com/u-root/u-root/pkg/mount/block"
+	"github.com/u-root/webboot/pkg/bootiso"
+	"github.com/u-root/webboot/pkg/menu"
+)
+
+type Distro struct {
+	IsoPattern    string
+	Checksum      string
+	ChecksumType  string
+	BootConfig    string
+	KernelParams  string
+	CustomConfigs []bootiso.Config
+	Mirrors       []Mirror
+}
+
+type Mirror struct {
+	Name string
+	Url  string
+}
+
+func (m *Mirror) Label() string {
+	return m.Name
+}
+
+var supportedDistros = map[string]Distro{}
+
+type CacheDevice struct {
+	Name       string
+	UUID       string
+	MountPoint string
+	IsoPath    string // set after iso is selected
+}
+
+func NewCacheDevice(device *block.BlockDev, mountPoint string) CacheDevice {
+	return CacheDevice{
+		Name:       device.Name,
+		UUID:       device.FsUUID,
+		MountPoint: mountPoint,
+	}
+}
+
+// ISO contains information of the iso user wants to boot.
+type ISO struct {
+	label    string
+	path     string
+	checksum string
+}
+
+var _ = menu.Entry(&ISO{})
+
+// Label is the string this iso displays in the menu page.
+func (i *ISO) Label() string {
+	return i.label
+}
+
+// Config represents one kind of configure of booting an iso.
+type Config struct {
+	label string
+}
+
+var _ = menu.Entry(&Config{})
+
+// Label is the string this iso displays in the menu page.
+func (c *Config) Label() string {
+	return c.label
+}
+
+// DownloadOption lets the user download an iso then boot it.
+type DownloadOption struct {
+}
+
+var _ = menu.Entry(&DownloadOption{})
+
+// Label is the string this iso displays in the menu page.
+func (d *DownloadOption) Label() string {
+	return "Download an ISO"
+}
+
+// DirOption represents a directory under cache directory.
+// It displays its sub-directory or iso files.
+type DirOption struct {
+	label string
+	path  string
+}
+
+var _ = menu.Entry(&DirOption{})
+
+// Label is the string this option displays in the menu page.
+func (d *DirOption) Label() string {
+	return d.label
+}
+
+type Interface struct {
+	label string
+}
+
+func (i *Interface) Label() string {
+	return i.label
+}
+
+type BootConfig struct {
+	image boot.OSImage
+}
+
+func (b *BootConfig) Label() string {
+	return b.image.Label()
+}

--- a/cmds/cli/utils.go
+++ b/cmds/cli/utils.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"sort"
+
+	"github.com/u-root/webboot/pkg/menu"
+)
+
+// WriteCounter counts the number of bytes written to it. It implements an io.Writer
+type WriteCounter struct {
+	received float64
+	expected float64
+	progress menu.Progress
+}
+
+func NewWriteCounter(expectedSize int64) WriteCounter {
+	return WriteCounter{0, float64(expectedSize), menu.NewProgress("", false)}
+}
+
+func (wc *WriteCounter) Write(p []byte) (int, error) {
+	n := len(p)
+	wc.received += float64(n)
+	wc.progress.Update(fmt.Sprintf("Downloading... %.2f%% (%.3f MB)\n\nPress <Esc> to cancel.", 100*(wc.received/wc.expected), wc.received/1000000))
+	return n, nil
+}
+
+func (wc *WriteCounter) Close() {
+	wc.progress.Close()
+}
+
+// download() will download a file from URL and save it to a temp file
+// If the download succeeds, the temp file will be copied to fPath
+func download(URL, fPath, downloadDir string) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", URL, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("Received http status code %s", resp.Status)
+	}
+	defer resp.Body.Close()
+
+	tempFile, err := ioutil.TempFile(downloadDir, "iso-download-")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tempFile.Name())
+
+	counter := NewWriteCounter(resp.ContentLength)
+
+	if _, err = io.Copy(tempFile, io.TeeReader(resp.Body, &counter)); err != nil {
+		counter.Close()
+		return err
+	}
+
+	counter.Close()
+
+	if _, err = tempFile.Seek(0, 0); err != nil {
+		return err
+	}
+
+	err = os.Rename(tempFile.Name(), fPath)
+	if err != nil {
+		return fmt.Errorf("Error on os.Rename: %v", err)
+	}
+
+	verbose("%q is downloaded at %q\n", URL, fPath)
+	return nil
+}
+
+func supportedDistroEntries() []menu.Entry {
+	entries := []menu.Entry{}
+	for distroName := range supportedDistros {
+		entries = append(entries, &Config{label: distroName})
+	}
+
+	sort.Slice(entries[:], func(i, j int) bool {
+		return entries[i].Label() < entries[j].Label()
+	})
+
+	return entries
+}


### PR DESCRIPTION
cli needs types.go and utils.go to compile. These two files are mostly
the same as the ones in cmds/webboot, but there are some small changes
to take out UI elements and unused functions.

Signed-off-by: Kelly Sun <sunkelly888@gmail.com>