### PR TITLE
Remove one of distroData()'s return values

### DIFF
--- a/cmds/webboot/webboot_test.go
+++ b/cmds/webboot/webboot_test.go
@@ -285,7 +285,7 @@ func TestDistroData(t *testing.T) {
 			uiEvents := make(chan ui.Event)
 			menus := make(chan string)
 			go tt.human(uiEvents, menus)
-			supportedDistros, err := distroData(uiEvents, menus, "./testdata")
+			err := distroData(uiEvents, menus, "./testdata")
 			if err != nil {
 				t.Fatalf("Error on distroData: %v", err)
 			}


### PR DESCRIPTION
Previously, distroData() returned a map[string]Distro, but this is not
necessary because supportedDistros is a map[string]Distro and is a
global variable.

Signed-off-by: Kelly Sun <sunkelly888@gmail.com>