### PR TITLE
Fix CI build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,41 +13,38 @@ jobs:
   # This job will build the linux kernel.
   buildKernel:
     runs-on: ubuntu-latest 
-    # Set the working directory to the correct place in $GOPATH.
-    defaults:
-      run:
-        working-directory: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
     # Environment variables
     env:
       # GOPATH is the current directory.
       GOPATH: ${{ github.workspace }}
       # Turn off modules because they are broken.
       GO111MODULE: off
+      # WEBBOOT is the where the code is checked out.
+      WEBBOOT: ${{ github.workspace }}/src/github.com/${{ github.repository }}
+    # Set the working directory to the correct place in $GOPATH.
+    defaults:
+      run:
+        working-directory: ${{ env.WEBBOOT }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
+          path: ${{ env.WEBBOOT }}
       - name: Kernel Build
         run: |
           ./nightly.sh
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
-      - uses: actions/upload-artifact@master
+          ls -l linux/arch/x86/boot/bzImage
+      - uses: actions/upload-artifact@v2
         with:
           name: nightly-kernel-build
-          path: linux/arch/x86/boot/bzImage
+          path: ${{ env.WEBBOOT }}/linux/arch/x86/boot/bzImage
+          if-no-files-found: error
+          retention-days: 30
   
   # This job will run the matrix of distros.
   runDistros:
     needs: buildKernel
     runs-on: ubuntu-latest
-    # Set the working directory to the correct place in $GOPATH.
-    defaults:
-      run:
-        working-directory: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
     # Environment variables
     env:
       # GOPATH is the current directory.
@@ -55,7 +52,20 @@ jobs:
       # Turn off modules because they are broken.
       GO111MODULE: off
       WEBBOOT_DISTRO: ${{ matrix.distro }}
+      # WEBBOOT is the where the code is checked out.
+      WEBBOOT: ${{ github.workspace }}/src/github.com/${{ github.repository }}
+      # qemu binary for integration test
+      UROOT_QEMU: qemu-system-x86_64
+    # Set the working directory to the correct place in $GOPATH.
+    defaults:
+      run:
+        working-directory: ${{ env.WEBBOOT }}
     strategy:
+      # Run at most 2 distros at a time.
+      max-parallel: 2
+      # Continue testing other distros on failure.
+      fail-fast: false
+      # List of distros
       matrix:
         distro:
           - Arch
@@ -67,16 +77,10 @@ jobs:
           - Linux Mint
           - Manjaro
           - Tinycore
-          - LHSCowboys
-          - DHSGaels
           - Ubuntu
     # Steps represent a sequence of tasks that will be executed as part of the
     # job
     steps:
-      - uses: actions/download-artifact@master
-        with:
-          name: nightly-kernel-build
-          path: linux/arch/x86/boot/bzImage
       - name: Install Go
         uses: actions/setup-go@v2
         with:
@@ -84,10 +88,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
+          path: ${{ env.WEBBOOT }}
       - name: Checkout dependencies
         run: |
           ./firsttime.sh
+      - uses: actions/download-artifact@v2
+        with:
+          name: nightly-kernel-build
+          path: ${{ env.WEBBOOT }}/linux/arch/x86/boot/bzImage
       - name: Test TestScript
         run: |
           go test -v ./integration

--- a/firsttime.sh
+++ b/firsttime.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-sudo apt-get install wireless-tools wpasupplicant libnl-3-dev libnl-genl-3-dev
+sudo apt-get install build-essential kexec-tools libelf-dev libnl-3-dev libnl-genl-3-dev libssl-dev qemu-system-x86 wireless-tools wpasupplicant
 
 go get -u github.com/u-root/u-root
 go get -u github.com/u-root/NiChrome/...


### PR DESCRIPTION
This likely will not fix booting on all distros, but I am hoping this
brings us from 0 to 1.

Changes:

* Remove a checkout code action. I believe this is checking out code
  over the kernel which was just build. This would explain the "No files
  were found with the provided path: linux/arch/x86/boot/bzImage" error.
* Remove these two builds: LHSCowboys and DHSGaels. This saves CPU
  minutes on our GitHub "free plan".

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>