### PR TITLE
Fix a few more CI issues

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,7 +51,6 @@ jobs:
       GOPATH: ${{ github.workspace }}
       # Turn off modules because they are broken.
       GO111MODULE: off
-      WEBBOOT_DISTRO: ${{ matrix.distro }}
       # WEBBOOT is the where the code is checked out.
       WEBBOOT: ${{ github.workspace }}/src/github.com/${{ github.repository }}
       # qemu binary and kernel for integration test
@@ -69,7 +68,7 @@ jobs:
       # List of distros
       matrix:
         distro:
-          - Tinycore
+          - TinyCore
           - Arch
           - CentOS 7
           - CentOS 8
@@ -102,4 +101,4 @@ jobs:
       - name: Test TestScript
         run: |
           ls -l ${{ env.UROOT_KERNEL }}
-          go test -v ./integration
+          WEBBOOT_DISTRO="${{ matrix.distro }}" go test -v ./integration

--- a/cmds/cli/ci.json
+++ b/cmds/cli/ci.json
@@ -124,24 +124,6 @@
 		"url":"http://tinycorelinux.net/11.x/x86_64/release/TinyCorePure64-11.1.iso"
 	}]
 },
-"LHSCowboys":{
-	"isoPattern":".*CorePure64-.+",
-	"bootConfig":"syslinux",
-	"kernelParams":"iso=UUID={{.UUID}}{{.IsoPath}}",
-	"mirrors":[{
-		"name":"Default",
-		"url":"https://github.com/u-root/webboot-distro/raw/master/iso/tinycore/10.x/x86_64/release/LHSCowboys.iso"
-	}]
-},
-"DHSGaels":{
-	"isoPattern":".*CorePure64-.+",
-	"bootConfig":"syslinux",
-	"kernelParams":"iso=UUID={{.UUID}}{{.IsoPath}}",
-	"mirrors":[{
-		"name":"Default",
-		"url":"https://github.com/u-root/webboot-distro/raw/master/iso/tinycore/10.x/x86_64/release/LHSCowboys.iso"
-	}]
-},
 "Ubuntu":{
 	"isoPattern":"^ubuntu-.+",
 	"checksum":"b45165ed3cd437b9ffad02a2aad22a4ddc69162470e2622982889ce5826f6e3d",

--- a/integration/basic_test.go
+++ b/integration/basic_test.go
@@ -16,8 +16,28 @@ import (
 	"github.com/u-root/u-root/pkg/vmtest"
 )
 
+var expectString = map[string]string{
+	"Arch":       "TODO_PLEASE_SET_EXPECT_STRING",
+	"CentOS 7":   "TODO_PLEASE_SET_EXPECT_STRING",
+	"CentOS 8":   "TODO_PLEASE_SET_EXPECT_STRING",
+	"Debian":     "TODO_PLEASE_SET_EXPECT_STRING",
+	"Fedora":     "TODO_PLEASE_SET_EXPECT_STRING",
+	"Kali":       "TODO_PLEASE_SET_EXPECT_STRING",
+	"Linux Mint": "TODO_PLEASE_SET_EXPECT_STRING",
+	"Manjaro":    "TODO_PLEASE_SET_EXPECT_STRING",
+	"TinyCore":   "5.4.3-tinycore64",
+	"Ubuntu":     "TODO_PLEASE_SET_EXPECT_STRING",
+}
+
 func TestScript(t *testing.T) {
 	webbootDistro := os.Getenv("WEBBOOT_DISTRO")
+	if _, ok := expectString[webbootDistro]; !ok {
+		if webbootDistro == "" {
+			t.Fatal("WEBBOOT_DISTRO is not set")
+		}
+		t.Fatalf("Unknown distro: %q", webbootDistro)
+	}
+
 	q, cleanup := vmtest.QEMUTest(t, &vmtest.Options{
 		Name: "ShellScript",
 		BuildOpts: uroot.Opts{
@@ -33,7 +53,7 @@ func TestScript(t *testing.T) {
 				"github.com/u-root/u-root/cmds/core/elvish",
 			),
 			ExtraFiles: []string{
-				"../cmds/cli/ci.json:/ci.json",
+				"../cmds/cli/ci.json:ci.json",
 				"/sbin/kexec",
 			},
 		},
@@ -57,7 +77,7 @@ func TestScript(t *testing.T) {
 	})
 	defer cleanup()
 
-	if err := q.Expect("5.4.3-tinycore64"); err != nil {
-		t.Fatal(`expected "5.4.3-tinycore64", got error: `, err)
+	if err := q.Expect(expectString[webbootDistro]); err != nil {
+		t.Fatalf("expected %q, got error: %v", expectString[webbootDistro], err)
 	}
 }


### PR DESCRIPTION
The biggest issue of which is WEBBOOT_DISTRO was not passed into the
test.

The rest of the fixes are mostly cosmetic. Only TinyCore has the correct
expect string set for now.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>