### PR TITLE
Change /etc/ssl to /etc/ssl/certs

### DIFF
--- a/integration/basic_test.go
+++ b/integration/basic_test.go
@@ -55,7 +55,7 @@ func TestScript(t *testing.T) {
 			ExtraFiles: []string{
 				"../cmds/cli/ci.json:ci.json",
 				"/sbin/kexec",
-				"/etc/ssl",
+				"/etc/ssl/certs",
 			},
 		},
 		QEMUOpts: qemu.Options{


### PR DESCRIPTION
Some of the subdirectories in CI are private and fail to read.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>