### PR TITLE
Run apt-get update in nightly CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
       - name: Checkout dependencies
         run: |
+          sudo apt-get update
           ./firsttime.sh
       - name: Build and test webboot
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -91,6 +91,7 @@ jobs:
           path: ${{ env.WEBBOOT }}
       - name: Checkout dependencies
         run: |
+          sudo apt-get update
           ./firsttime.sh
       - uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
The should hopefully fix the following error:

	E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/e/edk2/ovmf_0~20191122.bd85bf54-2ubuntu3.2_all.deb  404  Not Found [IP: 52.252.75.106 80]

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>