### PR TITLE
Fix nightly.yml

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,11 +31,11 @@ jobs:
       - name: Kernel Build
         run: |
           ./nightly.sh
-          ls -l linux/arch/x86/boot/bzImage
+          ls -l bzImage
       - uses: actions/upload-artifact@v2
         with:
           name: nightly-kernel-build
-          path: ${{ env.WEBBOOT }}/linux/arch/x86/boot/bzImage
+          path: ${{ env.WEBBOOT }}/bzImage
           if-no-files-found: error
           retention-days: 30
 
@@ -51,7 +51,7 @@ jobs:
       WEBBOOT: ${{ github.workspace }}/src/github.com/${{ github.repository }}
       # qemu binary and kernel for integration test
       UROOT_QEMU: qemu-system-x86_64
-      UROOT_KERNEL: ${{ github.workspace }}/src/github.com/${{ github.repository }}/linux/arch/x86/boot/bzImage
+      UROOT_KERNEL: ${{ github.workspace }}/src/github.com/${{ github.repository }}/bzImage
     # Set the working directory to the correct place in $GOPATH.
     defaults:
       run:


### PR DESCRIPTION
- Do not build the kernel every night; just wget it
- The vmtest package is a non-working thing; bypass most of it
- Since u-root is all about paths, to a shallow clone into this directory and use it
- build the u-root we git clone
- Build a u-root and use it
- Finish up fixing nightly
- Fix paths in nightly.yml
